### PR TITLE
Added command to nomad config and updated port map to use nomad env variable

### DIFF
--- a/dis-data-admin-ui.nomad
+++ b/dis-data-admin-ui.nomad
@@ -34,10 +34,12 @@ job "dis-data-admin-ui" {
       }
 
       config {
+        command = "${NOMAD_TASK_DIR}/start-task"
+
         image = "{{ECR_URL}}:concourse-{{REVISION}}"
 
         port_map {
-          http = 14000
+          http = "${NOMAD_PORT_http}"
         }
       }
 


### PR DESCRIPTION

### What

Added command to nomad config and updated port map to use nomad env variable.

Why? - because start-task is a script which pulls in the secrets from nomad and passes them as env variables to the container.

### How to review

LGTM

### Who can review

Anyone