### PR TITLE
use waitForURL instead of waitForTimeout

### DIFF
--- a/tests/component/editionsList.spec.js
+++ b/tests/component/editionsList.spec.js
@@ -23,7 +23,7 @@ test.describe('dataset seriesoverview/editions list page', () => {
         addValidAuthCookies(context);
         await page.goto('./series/mock-quarterly');
         await page.getByRole('link', { name: 'time-series' }).click();
-        await page.waitForTimeout(3000); // wait for new page to make fake api calls and load
+        await page.waitForURL('**/series/mock-quarterly/editions/time-series');
         await expect(page.url().toString()).toContain('series/mock-quarterly/editions/time-series');
     });
 });


### PR DESCRIPTION
### What

Using waitForURL is better as it waits for the url to change successfully rather than an arbitrary amonut of time that sometimes ins't enough when running in CI.

### How to review

Sanity check

### Who can review

Anyone
