### PR TITLE
Add date/time picker and add component to create edition page

### DIFF
--- a/src/app/actions/createDatasetEdition.js
+++ b/src/app/actions/createDatasetEdition.js
@@ -92,6 +92,7 @@ export async function createDatasetEdition(currentstate, formData) {
     const reqCfg = await SSRequestConfig(cookies);
     try {
         const data = await httpPost(reqCfg, `/datasets/${datasetID}/editions/${datasetEdition.edition}/versions`, datasetEdition);
+        actionResponse.success = true;
         if (data.status >= 400) {
             actionResponse.success = false;
             actionResponse.code = data.status;

--- a/src/app/actions/createDatasetEdition.js
+++ b/src/app/actions/createDatasetEdition.js
@@ -38,11 +38,10 @@ const mergeDateTimeErrors = (errors) => {
         return;
     } 
     if (errors.release_day || errors.release_month || errors.release_year || errors.release_hour || errors.release_minutes) {
-        console.log("we're in here")
         errors.release_date_time = ["A release time and date is required"];
     }
     return errors;
-}
+};
 
 export async function createDatasetEdition(currentstate, formData) {
     let actionResponse = {};
@@ -88,7 +87,7 @@ export async function createDatasetEdition(currentstate, formData) {
         return actionResponse;
     } 
 
-    datasetEdition.release_date =  new Date(datasetEdition.release_year, datasetEdition.release_month - 1, datasetEdition.release_day, datasetEdition.release_hour, datasetEdition.release_minutes).toISOString()
+    datasetEdition.release_date =  new Date(datasetEdition.release_year, datasetEdition.release_month - 1, datasetEdition.release_day, datasetEdition.release_hour, datasetEdition.release_minutes).toISOString();
 
     const reqCfg = await SSRequestConfig(cookies);
     try {

--- a/src/app/series/[id]/editions/create/CreateEdition.js
+++ b/src/app/series/[id]/editions/create/CreateEdition.js
@@ -93,7 +93,7 @@ export default function CreateEditionForm({ datasetID }) {
                     <Button variants="secondary" text="Copy from previous dataset"/>
                 </div>
 
-                <DateTimePicker id="release-date" errors={formState.errors}/>
+                <DateTimePicker id="release-date" dataTestId="release-date" errors={formState.errors}/>
 
                 <input id="quality-desingation-value" name="quality-desingation-value" type="hidden" value={qualityDesingation} />
                 <Select id="quality-desingation" 

--- a/src/app/series/[id]/editions/create/CreateEdition.js
+++ b/src/app/series/[id]/editions/create/CreateEdition.js
@@ -93,7 +93,7 @@ export default function CreateEditionForm({ datasetID }) {
                     <Button variants="secondary" text="Copy from previous dataset"/>
                 </div>
 
-                <DateTimePicker id="release-date" dataTestId="release-date" errors={formState.errors}/>
+                <DateTimePicker id="release-date" dataTestId="release-date" legend="Release date and time" description="For example, 31 3 1980" errors={formState.errors}/>
 
                 <input id="quality-desingation-value" name="quality-desingation-value" type="hidden" value={qualityDesingation} />
                 <Select id="quality-desingation" 

--- a/src/app/series/[id]/editions/create/CreateEdition.js
+++ b/src/app/series/[id]/editions/create/CreateEdition.js
@@ -13,6 +13,7 @@ import Hero from "@/components/hero/Hero";
 import Panel from "@/components/panel/Panel";
 import MultiContentItems from '@/components/multi-content/MultiContentItems';
 import ResumableFileUpload from "@/components/file-upload/ResumableFileUpload";
+import DateTimePicker from '@/components/date-time/DateTimePicker';
 
 
 export default function CreateEditionForm({ datasetID }) {
@@ -86,11 +87,14 @@ export default function CreateEditionForm({ datasetID }) {
                     error={ (formState.errors && formState.errors.edition_title) ? {id:'edition-title-error', text: formState.errors.edition_title} : null}
                 />
 
-                <h2 className="ons-u-mt-xl">Dataset details</h2>
+                <h2 className="ons-u-mt-xl">Dataset version details</h2>
                 <p>The information in these fields may be copied from the most recent version.</p>
                 <div className="ons-u-mb-l">
                     <Button variants="secondary" text="Copy from previous dataset"/>
                 </div>
+
+                <DateTimePicker id="release-date" errors={formState.errors}/>
+
                 <input id="quality-desingation-value" name="quality-desingation-value" type="hidden" value={qualityDesingation} />
                 <Select id="quality-desingation" 
                     label={{text: "Quality designation", description: "Something about what quality designation means"}} 

--- a/src/components/date-time/DateTimePicker.js
+++ b/src/components/date-time/DateTimePicker.js
@@ -1,0 +1,118 @@
+import { useState } from "react";
+import { DatesInput, Fieldset, TextInput, sanitiseString } from "author-design-system-react";
+
+export default function DateTimePicker(props) {
+    const [day, setDay] = useState("");
+    const [month, setMonth] = useState("");
+    const [year, setYear] = useState("");
+    const [hour, setHour] = useState("");
+    const [minutes, setMinutes] = useState("");
+
+    const sanitisedId = sanitiseString(props.id);
+    const sanitisedDataTestId = sanitiseString(props.dataTestId);
+
+    const fields = (
+        <div className="ons-field-group">
+            <TextInput
+                id={`${sanitisedId}-day`}
+                label={{
+                    text: "Day",
+                    id: `${sanitisedId}-day-label`,
+                }}
+                onChange={e => setDay(e.target.value)}
+                width="2"
+                min={1}
+                max={31}
+                maxLength={2}
+                type="number"
+                value={day}
+                name={"release-date-day"}
+                dataTestId={`${sanitisedDataTestId}-day`}
+            />
+
+            <TextInput
+                id={`${sanitisedId}-month`}
+                label={{
+                    text: "Month",
+                    id: `${sanitisedId}-month-label`,
+                }}
+                onChange={e => setMonth(e.target.value)}
+                width="2"
+                min={1}
+                max={12}
+                maxLength={2}
+                type="number"
+                value={month}
+                name={"release-date-month"}
+                dataTestId={`${sanitisedDataTestId}-month`}
+            />
+
+            <TextInput
+                id={`${sanitisedId}-year`}
+                label={{
+                    text: "Year",
+                    id: `${sanitisedId}-year-label`,
+                }}
+                onChange={e => setYear(e.target.value)}
+                width="4"
+                min={1000}
+                max={3000}
+                maxLength={4}
+                type="number"
+                value={year}
+                name={"release-date-year"}
+                dataTestId={`${sanitisedDataTestId}-year`}
+            />
+
+            <TextInput
+                id={`${sanitisedId}-hour`}
+                label={{
+                    text: "Hours",
+                    id: `${sanitisedId}-hour-label`,
+                }}
+                onChange={e => setHour(e.target.value)}
+                width="3"
+                min={0}
+                max={24}
+                maxLength={2}
+                type="number"
+                value={hour}
+                name={"release-date-hour"}
+                dataTestId={`${sanitisedDataTestId}-hour`}
+            />
+
+            <TextInput
+                id={`${sanitisedId}-minutes`}
+                label={{
+                    text: "Minutes",
+                    id: `${sanitisedId}-minutes-label`,
+                }}
+                onChange={e => setMinutes(e.target.value)}
+                width="3"
+                min={0}
+                max={59}
+                maxLength={2}
+                type="number"
+                value={minutes}
+                name={"release-date-minutes"}
+                dataTestId={`${sanitisedDataTestId}-minutes`}
+            />
+        </div>
+    )
+
+    console.log(props.errors)
+    return (
+        <div className="ons-u-mb-l">
+            <Fieldset
+                id={sanitisedId}
+                legend="Release date and time"
+                description="For example, 31 3 1980"
+                dataTestId={`fieldset-${sanitisedDataTestId}`}
+                error={(props.errors && props.errors.release_date_time) ? {id:'release-date-time-error', text: props.errors.release_date_time} : null} 
+            >
+                {fields}
+            </Fieldset>
+
+        </div>
+    );
+}

--- a/src/components/date-time/DateTimePicker.js
+++ b/src/components/date-time/DateTimePicker.js
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { DatesInput, Fieldset, TextInput, sanitiseString } from "author-design-system-react";
+import { Fieldset, TextInput, sanitiseString } from "author-design-system-react";
 
 export default function DateTimePicker(props) {
     const [day, setDay] = useState("");
@@ -98,9 +98,8 @@ export default function DateTimePicker(props) {
                 dataTestId={`${sanitisedDataTestId}-minutes`}
             />
         </div>
-    )
+    );
 
-    console.log(props.errors)
     return (
         <div className="ons-u-mb-l">
             <Fieldset

--- a/src/components/date-time/DateTimePicker.js
+++ b/src/components/date-time/DateTimePicker.js
@@ -104,8 +104,8 @@ export default function DateTimePicker(props) {
         <div className="ons-u-mb-l">
             <Fieldset
                 id={sanitisedId}
-                legend="Release date and time"
-                description="For example, 31 3 1980"
+                legend={props.legend}
+                description={props.description}
                 dataTestId={`fieldset-${sanitisedDataTestId}`}
                 error={(props.errors && props.errors.release_date_time) ? {id:'release-date-time-error', text: props.errors.release_date_time} : null} 
             >

--- a/src/components/date-time/DateTimePicker.test.js
+++ b/src/components/date-time/DateTimePicker.test.js
@@ -1,0 +1,58 @@
+import '@testing-library/jest-dom'
+import { render, screen, fireEvent } from '@testing-library/react'
+import DateTimePicker from './DateTimePicker';
+
+describe("DateTimerPicker", () => {
+    it("renders correctly", () => {
+        render(<DateTimePicker id="release-date" dataTestId="release-date"/>);
+        const day = screen.getByTestId("release-date-day");
+        expect(day).toBeInTheDocument();
+
+        const month = screen.getByTestId("release-date-month");
+        expect(month).toBeInTheDocument();
+
+        const year = screen.getByTestId("release-date-year");
+        expect(year).toBeInTheDocument();
+
+        const hour = screen.getByTestId("release-date-hour");
+        expect(hour).toBeInTheDocument();
+
+        const minutes = screen.getByTestId("release-date-minutes");
+        expect(minutes).toBeInTheDocument();
+    });
+
+    it("onChange handler updates day state", () => {
+        render(<DateTimePicker id="release-date" dataTestId="release-date"/>);
+        const day = screen.getByTestId("release-date-day");
+        fireEvent.change(day, {target: {value: "1"}});
+        expect(day.value).toBe("1");
+    });
+
+    it("onChange handler updates month state", () => {
+        render(<DateTimePicker id="release-date" dataTestId="release-date"/>);
+        const month = screen.getByTestId("release-date-month");
+        fireEvent.change(month, {target: {value: "1"}});
+        expect(month.value).toBe("1");
+    });
+
+    it("onChange handler updates year state", () => {
+        render(<DateTimePicker id="release-date" dataTestId="release-date"/>);
+        const year = screen.getByTestId("release-date-year");
+        fireEvent.change(year, {target: {value: "2020"}});
+        expect(year.value).toBe("2020");
+    });
+
+    it("onChange handler updates hour state", () => {
+        render(<DateTimePicker id="release-date" dataTestId="release-date"/>);
+        const hour = screen.getByTestId("release-date-hour");
+        fireEvent.change(hour, {target: {value: "09"}});
+        expect(hour.value).toBe("09");
+    });
+
+    it("onChange handler updates minutes state", () => {
+        render(<DateTimePicker id="release-date" dataTestId="release-date"/>);
+        const minutes = screen.getByTestId("release-date-minutes");
+        fireEvent.change(minutes, {target: {value: "30"}});
+        expect(minutes.value).toBe("30");
+    });
+});

--- a/src/components/date-time/DateTimePicker.test.js
+++ b/src/components/date-time/DateTimePicker.test.js
@@ -2,9 +2,13 @@ import '@testing-library/jest-dom'
 import { render, screen, fireEvent } from '@testing-library/react'
 import DateTimePicker from './DateTimePicker';
 
+renderDateTimePicker = () => {
+    render(<DateTimePicker id="release-date" dataTestId="release-date" legend="Test date and time" description=""/>);
+}
+
 describe("DateTimerPicker", () => {
     it("renders correctly", () => {
-        render(<DateTimePicker id="release-date" dataTestId="release-date"/>);
+        renderDateTimePicker();
         const day = screen.getByTestId("release-date-day");
         expect(day).toBeInTheDocument();
 
@@ -22,35 +26,35 @@ describe("DateTimerPicker", () => {
     });
 
     it("onChange handler updates day state", () => {
-        render(<DateTimePicker id="release-date" dataTestId="release-date"/>);
+        renderDateTimePicker();
         const day = screen.getByTestId("release-date-day");
         fireEvent.change(day, {target: {value: "1"}});
         expect(day.value).toBe("1");
     });
 
     it("onChange handler updates month state", () => {
-        render(<DateTimePicker id="release-date" dataTestId="release-date"/>);
+        renderDateTimePicker();
         const month = screen.getByTestId("release-date-month");
         fireEvent.change(month, {target: {value: "1"}});
         expect(month.value).toBe("1");
     });
 
     it("onChange handler updates year state", () => {
-        render(<DateTimePicker id="release-date" dataTestId="release-date"/>);
+        renderDateTimePicker();
         const year = screen.getByTestId("release-date-year");
         fireEvent.change(year, {target: {value: "2020"}});
         expect(year.value).toBe("2020");
     });
 
     it("onChange handler updates hour state", () => {
-        render(<DateTimePicker id="release-date" dataTestId="release-date"/>);
+        renderDateTimePicker();
         const hour = screen.getByTestId("release-date-hour");
         fireEvent.change(hour, {target: {value: "09"}});
         expect(hour.value).toBe("09");
     });
 
     it("onChange handler updates minutes state", () => {
-        render(<DateTimePicker id="release-date" dataTestId="release-date"/>);
+        renderDateTimePicker();
         const minutes = screen.getByTestId("release-date-minutes");
         fireEvent.change(minutes, {target: {value: "30"}});
         expect(minutes.value).toBe("30");

--- a/tests/component/createEdition.spec.js
+++ b/tests/component/createEdition.spec.js
@@ -33,6 +33,11 @@ test.describe("Create edition page", () => {
         await page.goto("./series/mock-quarterly/editions/create");
         await page.getByTestId("edition-id").fill("test-id");
         await page.getByTestId("edition-title").fill("Test title");
+        await page.getByTestId("release-date-day").fill("1");
+        await page.getByTestId("release-date-month").fill("1");
+        await page.getByTestId("release-date-year").fill("2020");
+        await page.getByTestId("release-date-hour").fill("9");
+        await page.getByTestId("release-date-minutes").fill("30");
         await page.getByTestId("select-quality-desingation").selectOption("official");
         await page.getByTestId("usage-notes-input-0").fill("Test usage notes");
         await page.getByTestId("usage-notes-textarea-0").fill("Something about usage notes");
@@ -63,6 +68,7 @@ test.describe("Create edition page", () => {
         await expect(page.getByLabel("There was a problem").getByText("Edition title is required")).toBeVisible();
         await expect(page.getByLabel("There was a problem").getByText("Quality designation is required")).toBeVisible();
         await expect(page.getByLabel("There was a problem").getByText("File upload is required")).toBeVisible();
+        await expect(page.getByLabel("There was a problem").getByText("A release time and date is required")).toBeVisible();
 
         await expect(page.getByTestId("field-edition-id-error").getByText("Edition ID is required")).toBeVisible();
         await expect(page.getByTestId("field-edition-title-error").getByText("Edition title is required")).toBeVisible();  


### PR DESCRIPTION
### What

Add a date time "picker" (group of inputs) that allows a user to set a release date and time
Note: date time picker follows design system pattern but extends it to add additional fields for hours and minutes. From a code point of view extending the current `DateInput` component from the design system wouldn't work so we've re-created it but mirrored the code style (mostly) of the design system

### How to review

Create a new edition and manually set a release date and time. Check edition is created with correct date/time. 
Sanity check.

### Who can review

Anyone
