### PR TITLE
changed request to only retrieve static datasets

### DIFF
--- a/src/app/series/page.js
+++ b/src/app/series/page.js
@@ -9,7 +9,7 @@ import { mapListItems } from "./mapper";
 
 export default async function Series() {
     const reqCfg = await SSRequestConfig(cookies);
-    const data = await httpGet(reqCfg, "/datasets");
+    const data = await httpGet(reqCfg, "/datasets?type=static");
 
     let error = false;
     const listItems = [];


### PR DESCRIPTION
### What

Change API call to only retrieve static datasets

### How to review

Run `dataset-catalogue` stack and ensure the Dataset Series page only displays static datasets

### Who can review

Anyone
