### PR TITLE
Feature/convert topic i ds to titles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ dist-ssr
 # Testing
 test-results
 playwright-report
+coverage
 
 .env
 .env~

--- a/Makefile
+++ b/Makefile
@@ -29,8 +29,8 @@ node-modules:
 	$(NPM) install --legacy-peer-deps
 
 .PHONY: test
-test: node-modules## Runs unit tests including checks for race conditions and returns coverage
-	$(NPM) run test
+test: node-modules ## Runs unit tests including checks for race conditions and returns coverage
+	$(NPM) run test -- --coverage
 
 .PHONY: test-component
 test-component: ## Runs component test suite

--- a/src/app/series/[id]/page.js
+++ b/src/app/series/[id]/page.js
@@ -65,7 +65,7 @@ export default async function Dataset({ params }) {
                             <h2 className="ons-u-mt-m@xxs@m">Description</h2>
                             <p data-testid="description-field">{dataset.description}</p>
 
-                            {topicTitles && topicTitles.length > 0 && (
+                            {topicTitles && (
                                 <>
                                     <h2 className="ons-u-mt-m@xxs@m">Topics</h2>
                                     <ul data-testid="topics-field">

--- a/src/app/series/[id]/page.js
+++ b/src/app/series/[id]/page.js
@@ -42,7 +42,7 @@ export default async function Dataset({ params }) {
 
     const createURL = `${id}/editions/create`;
     const dataset = datasetResp?.current || datasetResp?.next || datasetResp;
-    const topicTitles = dataset.topics && dataset.topics.length > 0 ? await convertTopicIDsToTopicTitles(dataset.topics, reqCfg) : undefined;
+    const topicTitles = dataset.topics && dataset.topics.length > 0 ? await convertTopicIDsToTopicTitles(dataset.topics, reqCfg) : null;
     return (
         <>
             { !datasetError ? 

--- a/src/app/series/[id]/page.js
+++ b/src/app/series/[id]/page.js
@@ -42,7 +42,7 @@ export default async function Dataset({ params }) {
 
     const createURL = `${id}/editions/create`;
     const dataset = datasetResp?.current || datasetResp?.next || datasetResp;
-    const topicTitles = dataset.topics && dataset.topics.length > 0 ? await convertTopicIDsToTopicTitles(dataset.topics, reqCfg) : null;
+    const topicTitles = await convertTopicIDsToTopicTitles(dataset.topics, reqCfg);
     return (
         <>
             { !datasetError ? 

--- a/src/app/series/[id]/page.js
+++ b/src/app/series/[id]/page.js
@@ -42,7 +42,7 @@ export default async function Dataset({ params }) {
 
     const createURL = `${id}/editions/create`;
     const dataset = datasetResp?.current || datasetResp?.next || datasetResp;
-    const topicTitles = await convertTopicIDsToTopicTitles(dataset.topics, reqCfg);
+    const topicTitles = dataset.topics && dataset.topics.length > 0 ? await convertTopicIDsToTopicTitles(dataset.topics, reqCfg) : undefined;
     return (
         <>
             { !datasetError ? 

--- a/src/app/series/[id]/page.js
+++ b/src/app/series/[id]/page.js
@@ -7,6 +7,7 @@ import Hero from "@/components/hero/Hero";
 import List from "@/components/list/List";
 import Panel from "@/components/panel/Panel";
 import { mapListItems } from './mapper';
+import { convertTopicIDsToTopicTitles } from "@/utils/topics/topics";
 
 export default async function Dataset({ params }) {
     const { id } = await params;
@@ -41,6 +42,7 @@ export default async function Dataset({ params }) {
 
     const createURL = `${id}/editions/create`;
     const dataset = datasetResp?.current || datasetResp?.next || datasetResp;
+    const topicTitles = await convertTopicIDsToTopicTitles(dataset.topics, reqCfg);
     return (
         <>
             { !datasetError ? 
@@ -63,12 +65,12 @@ export default async function Dataset({ params }) {
                             <h2 className="ons-u-mt-m@xxs@m">Description</h2>
                             <p data-testid="description-field">{dataset.description}</p>
 
-                            {dataset.topics && dataset.topics.length > 0 && (
+                            {topicTitles && topicTitles.length > 0 && (
                                 <>
                                     <h2 className="ons-u-mt-m@xxs@m">Topics</h2>
                                     <ul data-testid="topics-field">
-                                        {dataset.topics.map((topic, index) => (
-                                            <li className="ons-u-mb-no" key={index}>{topic}</li>
+                                        {topicTitles.map((topicTitle, index) => (
+                                            <li className="ons-u-mb-no" key={index}>{topicTitle}</li>
                                         ))}
                                     </ul>
                                 </>

--- a/src/utils/topics/topics.js
+++ b/src/utils/topics/topics.js
@@ -1,0 +1,21 @@
+import { logError } from "../log/log";
+import { httpGet } from "@/utils/request/request";
+
+export async function convertTopicIDsToTopicTitles(topicIDs, reqCfg) {
+    if (!topicIDs || topicIDs.length === 0) {
+        return [];
+    }
+
+    const topicTitles = await Promise.all(
+        topicIDs.map(async (topicID) => {
+            try {
+                const response = await httpGet(reqCfg, `/topics/${topicID}`);
+                return response?.title || `${topicID} - unable to find topic title`;
+            } catch (error) {
+                logError("error fetching topic", topicID, null, error);
+                return `${topicID} - unable to find topic title`;
+            }
+        })
+    );
+    return topicTitles;
+}

--- a/src/utils/topics/topics.js
+++ b/src/utils/topics/topics.js
@@ -2,10 +2,6 @@ import { logError } from "../log/log";
 import { httpGet } from "@/utils/request/request";
 
 export async function convertTopicIDsToTopicTitles(topicIDs, reqCfg) {
-    if (!topicIDs || topicIDs.length === 0) {
-        return [];
-    }
-
     const topicTitles = await Promise.all(
         topicIDs.map(async (topicID) => {
             try {

--- a/src/utils/topics/topics.js
+++ b/src/utils/topics/topics.js
@@ -2,15 +2,21 @@ import { logError } from "../log/log";
 import { httpGet } from "@/utils/request/request";
 
 export function convertTopicIDsToTopicTitles(topicIDs, reqCfg) {
+    if (!topicIDs || topicIDs.length === 0) {
+        return null;
+    }
+
     return Promise.all(
-        topicIDs.map(async (topicID) => {
-            try {
-                const response = await httpGet(reqCfg, `/topics/${topicID}`);
-                return response?.current?.title || response?.next?.title || response?.title || `${topicID} - unable to find topic title`;
-            } catch (error) {
-                logError("error fetching topic", topicID, null, error);
-                return `${topicID} - unable to find topic title`;
-            }
-        })
+        topicIDs.map((topicID) => getTopicTitle(topicID, reqCfg))
     );
+}
+
+export async function getTopicTitle(topicID, reqCfg) {
+    try {
+        const response = await httpGet(reqCfg, `/topics/${topicID}`);
+        return response?.current?.title || response?.next?.title || response?.title || `${topicID} - unable to find topic title`;
+    } catch (error) {
+        logError("error fetching topic", topicID, null, error);
+        return `${topicID} - unable to find topic title`;
+    }
 }

--- a/src/utils/topics/topics.js
+++ b/src/utils/topics/topics.js
@@ -1,8 +1,8 @@
 import { logError } from "../log/log";
 import { httpGet } from "@/utils/request/request";
 
-export async function convertTopicIDsToTopicTitles(topicIDs, reqCfg) {
-    const topicTitles = await Promise.all(
+export function convertTopicIDsToTopicTitles(topicIDs, reqCfg) {
+    return Promise.all(
         topicIDs.map(async (topicID) => {
             try {
                 const response = await httpGet(reqCfg, `/topics/${topicID}`);
@@ -13,5 +13,4 @@ export async function convertTopicIDsToTopicTitles(topicIDs, reqCfg) {
             }
         })
     );
-    return topicTitles;
 }

--- a/src/utils/topics/topics.js
+++ b/src/utils/topics/topics.js
@@ -10,7 +10,7 @@ export async function convertTopicIDsToTopicTitles(topicIDs, reqCfg) {
         topicIDs.map(async (topicID) => {
             try {
                 const response = await httpGet(reqCfg, `/topics/${topicID}`);
-                return response?.title || `${topicID} - unable to find topic title`;
+                return response?.current?.title || response?.next?.title || response?.title || `${topicID} - unable to find topic title`;
             } catch (error) {
                 logError("error fetching topic", topicID, null, error);
                 return `${topicID} - unable to find topic title`;

--- a/src/utils/topics/topics.test.js
+++ b/src/utils/topics/topics.test.js
@@ -6,7 +6,7 @@ jest.mock("../../utils/request/request");
 jest.mock("../log/log");
 
 describe("convertTopicIDsToTopicTitles", () => {
-    const reqCfg = { headers: { Authorization: "Bearer token" } };
+    const reqCfg = null;
 
     afterEach(() => {
         jest.clearAllMocks();

--- a/src/utils/topics/topics.test.js
+++ b/src/utils/topics/topics.test.js
@@ -1,0 +1,70 @@
+import { convertTopicIDsToTopicTitles } from "./topics";
+import { httpGet } from "../../utils/request/request";
+import { logError } from "../log/log";
+
+jest.mock("../../utils/request/request");
+jest.mock("../log/log");
+
+describe("convertTopicIDsToTopicTitles", () => {
+    const reqCfg = { headers: { Authorization: "Bearer token" } };
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("should return an empty array if topicIDs is null", async () => {
+        const result = await convertTopicIDsToTopicTitles(null, reqCfg);
+        expect(result).toEqual([]);
+    });
+
+    it("should return an empty array if topicIDs is an empty array", async () => {
+        const result = await convertTopicIDsToTopicTitles([], reqCfg);
+        expect(result).toEqual([]);
+    });
+
+    it("should return topic titles for valid topicIDs", async () => {
+        httpGet.mockResolvedValueOnce({ title: "Topic 1" });
+        httpGet.mockResolvedValueOnce({ title: "Topic 2" });
+
+        const result = await convertTopicIDsToTopicTitles(["id1", "id2"], reqCfg);
+
+        expect(result).toEqual(["Topic 1", "Topic 2"]);
+        expect(httpGet).toHaveBeenCalledTimes(2);
+        expect(httpGet).toHaveBeenCalledWith(reqCfg, "/topics/id1");
+        expect(httpGet).toHaveBeenCalledWith(reqCfg, "/topics/id2");
+    });
+
+    it("should return fallback title if a topic title is missing", async () => {
+        httpGet.mockResolvedValueOnce({});
+        httpGet.mockResolvedValueOnce({ title: "Topic 2" });
+
+        const result = await convertTopicIDsToTopicTitles(["id1", "id2"], reqCfg);
+
+        expect(result).toEqual(["id1 - unable to find topic title", "Topic 2"]);
+    });
+
+    it("should log an error and return fallback title if an API call fails", async () => {
+        httpGet.mockRejectedValueOnce(new Error("API error"));
+        httpGet.mockResolvedValueOnce({ title: "Topic 2" });
+
+        const result = await convertTopicIDsToTopicTitles(["id1", "id2"], reqCfg);
+
+        expect(result).toEqual(["id1 - unable to find topic title", "Topic 2"]);
+        expect(logError).toHaveBeenCalledWith("error fetching topic", "id1", null, expect.any(Error));
+    });
+
+    it("should handle multiple API call failures", async () => {
+        httpGet.mockRejectedValueOnce(new Error("API error 1"));
+        httpGet.mockRejectedValueOnce(new Error("API error 2"));
+
+        const result = await convertTopicIDsToTopicTitles(["id1", "id2"], reqCfg);
+
+        expect(result).toEqual([
+            "id1 - unable to find topic title",
+            "id2 - unable to find topic title",
+        ]);
+        expect(logError).toHaveBeenCalledTimes(2);
+        expect(logError).toHaveBeenCalledWith("error fetching topic", "id1", null, expect.any(Error));
+        expect(logError).toHaveBeenCalledWith("error fetching topic", "id2", null, expect.any(Error));
+    });
+});

--- a/src/utils/topics/topics.test.js
+++ b/src/utils/topics/topics.test.js
@@ -12,16 +12,6 @@ describe("convertTopicIDsToTopicTitles", () => {
         jest.clearAllMocks();
     });
 
-    it("should return an empty array if topicIDs is null", async () => {
-        const result = await convertTopicIDsToTopicTitles(null, reqCfg);
-        expect(result).toEqual([]);
-    });
-
-    it("should return an empty array if topicIDs is an empty array", async () => {
-        const result = await convertTopicIDsToTopicTitles([], reqCfg);
-        expect(result).toEqual([]);
-    });
-
     it("should return topic titles for valid topicIDs", async () => {
         httpGet.mockResolvedValueOnce({ title: "Topic 1" });
         httpGet.mockResolvedValueOnce({ title: "Topic 2" });

--- a/tests/component/datasets.spec.js
+++ b/tests/component/datasets.spec.js
@@ -34,8 +34,8 @@ test.describe('series', () => {
         await expect(page.getByTestId('title-field')).toContainText('Mock Dataset');
         await expect(page.getByTestId('description-field')).toContainText('This is a mock dataset test description');
         await expect(page.getByTestId('topics-field')).toBeVisible();
-        await expect(page.getByTestId('topics-field')).toContainText('Education');
-        await expect(page.getByTestId('topics-field')).toContainText('Business');
+        await expect(page.getByTestId('topics-field')).toContainText('Topic 1');
+        await expect(page.getByTestId('topics-field')).toContainText('Topic 2');
         await expect(page.getByTestId('last-updated-field')).toContainText('1 January 2000');
         await expect(page.getByTestId('license-field')).toContainText('My License');
         await expect(page.getByTestId('next-release-field')).toContainText('TBC');
@@ -68,7 +68,8 @@ test.describe('series', () => {
         await expect(page.getByTestId('title-field')).toContainText('Minimal Mock Dataset');
         await expect(page.getByTestId('description-field')).toContainText('This is a minimal mock dataset test description');
         await expect(page.getByTestId('topics-field')).toBeVisible();
-        await expect(page.getByTestId('topics-field')).toContainText('Economy');
+        await expect(page.getByTestId('topics-field')).toContainText('Topic 1');
+        await expect(page.getByTestId('topics-field')).toContainText('id3 - unable to find topic title');
         await expect(page.getByTestId('last-updated-field')).toContainText('missing date');
         await expect(page.getByTestId('license-field')).toContainText('My Minimal License');
         await expect(page.getByTestId('next-release-field')).not.toBeVisible();

--- a/tests/fakeapi/server.js
+++ b/tests/fakeapi/server.js
@@ -3,6 +3,7 @@ import express from "express";
 import { datasetList } from "../mocks/datasets.mjs";
 import { editions } from "../mocks/editions.mjs";
 import { edition } from "../mocks/edition.mjs";
+import { topicList } from "../mocks/topics.mjs";
 import { versions } from "../mocks/versions.mjs";
 
 
@@ -45,6 +46,10 @@ app.get("/datasets/:id/editions/:editionID/versions", (req, res) => {
 
 app.post("/datasets/:id/editions/:editionID/versions", (req, res) => {
     res.send({status: 201});
+});
+
+app.get("/topics/:id", (req, res) => {
+    res.send(topicList.items.find(item => item.id === req.params.id));
 });
 
 app.listen(PORT, () => {

--- a/tests/mocks/datasets.mjs
+++ b/tests/mocks/datasets.mjs
@@ -20,7 +20,7 @@ export const datasetList = {
             "state": "published",
             "title": "Mock Dataset",
             "unit_of_measure": "Percentage",
-            "topics": ["Education", "Business"],
+            "topics": ["id1", "id2"],
             "contacts": [
                 {
                     "email": "contactOne@ons.gov.uk",
@@ -48,7 +48,7 @@ export const datasetList = {
             "description": "This is a minimal mock dataset test description",
             "id": "mock-minimal",
             "title": "Minimal Mock Dataset",
-            "topics": ["Economy"],
+            "topics": ["id1", "id3"],
             "contacts": [
                 {
                     "email": "contactOne@ons.gov.uk",

--- a/tests/mocks/topics.mjs
+++ b/tests/mocks/topics.mjs
@@ -1,0 +1,12 @@
+export const topicList = {
+    "items": [
+        {
+            "id": "id1",
+            "title": "Topic 1"
+        },
+        {
+            "id": "id2",
+            "title": "Topic 2"
+        }
+    ]
+}


### PR DESCRIPTION
### What

- Added coverage for unit tests
- TopicID's are converted to topic titles before being displayed

### How to review

- Within dp-compose, `v2/stacks/dataset-catalogue/provisioning/mongodb/datasets.json`, change the topics to `"topics": ["topic-0", "topic-1"]`
- switch to `feature/seeded-topics-with-locked-ids` wihtin `dp-topic-api`
- run the `dataset-catalogue` stack
- run `make database-seed` within root of dp-topic-api
- Check out dataset-series page locally and see if topics are displayed

### Who can review

Anyone
