### PR TITLE
Feature/make series form error message clearer

### DIFF
--- a/src/app/actions/datasetSeries.js
+++ b/src/app/actions/datasetSeries.js
@@ -57,7 +57,14 @@ const createResponse = async (datasetSeriesSubmission, result, url, type)  =>  {
                 response.success = false;
                 response.recentlySubmitted = false;
                 response.code = data.status;
-                response.httpError = data.errorMessage;
+                
+                if (data.errorMessage.trim() === "dataset already exists") {
+                    response.httpError = `A dataset series with an ID of ${datasetSeriesSubmission.id} already exists`;
+                } else if (data.errorMessage.trim() === "dataset title already exists") {
+                    response.httpError = `A dataset series titled ${datasetSeriesSubmission.title} already exists`;
+                } else {
+                    response.httpError = data.errorMessage;
+                }
             } else {
                 response.recentlySubmitted = true;
                 logInfo("dataset series created/updated successfully", {dataset_id: datasetSeriesSubmission.id}, null);

--- a/tests/component/seriesCreate.spec.js
+++ b/tests/component/seriesCreate.spec.js
@@ -79,7 +79,7 @@ test.describe("Create series page", () => {
         await page.getByRole("button", { name: /Add contact/i }).click();
         await page.getByRole("button", { name: /Save new dataset series/i }).click();
 
-        await expect(page.getByText("dataset series already exists")).toBeVisible();
+        await expect(page.getByText("A dataset series with an ID of duplicate-id already exists")).toBeVisible();
     });
 
     test("Does not allow duplicate dataset series title to be created", async ({ page, context }) => {
@@ -96,6 +96,6 @@ test.describe("Create series page", () => {
         await page.getByRole("button", { name: /Add contact/i }).click();
         await page.getByRole("button", { name: /Save new dataset series/i }).click();
 
-        await expect(page.getByText("dataset title already exists")).toBeVisible();
+        await expect(page.getByText("A dataset series titled duplicate-title already exists")).toBeVisible();
     });
 });

--- a/tests/component/seriesEdit.spec.js
+++ b/tests/component/seriesEdit.spec.js
@@ -40,6 +40,6 @@ test.describe("Edit series page", () => {
         await page.getByTestId("dataset-series-title").fill("duplicate-title");
         await page.getByRole("button", { name: /Save new dataset series/i }).click();
 
-        await expect(page.getByText("dataset title already exists")).toBeVisible();
+        await expect(page.getByText("A dataset series titled duplicate-title already exists")).toBeVisible();
     });
 });

--- a/tests/fakeapi/server.js
+++ b/tests/fakeapi/server.js
@@ -19,7 +19,7 @@ app.get("/datasets", (req, res) => {
 
 app.post("/datasets", (req, res) => {
     if (req.body.id == 'duplicate-id') {
-        res.status(409).send("dataset series already exists");
+        res.status(409).send("dataset already exists");
         return;
     }
 


### PR DESCRIPTION
### What

Make error message clearer when duplicate series ID or title is given

### How to review

Check changes are ok
Error messages show as expected on create and edit series pages

### Who can review

Anyone
