### PR TITLE
Fix: correctly set create button on edition overview

### DIFF
--- a/src/app/series/[id]/editions/[editionID]/page.js
+++ b/src/app/series/[id]/editions/[editionID]/page.js
@@ -86,7 +86,7 @@ export default async function Edition({ params, searchParams }) {
                 breadcrumbs={breadcrumbs}
                 showPanel={unpublishedVersion}
                 panelText="An unpublished version exists so cannot add new dataset version."
-                disableButton={!unpublishedVersion}
+                disableButton={unpublishedVersion}
             /> 
             <div className="ons-grid ons-u-mt-xl">
                 <div className="ons-grid__col ons-col-4@m">

--- a/src/app/series/[id]/editions/[editionID]/page.js
+++ b/src/app/series/[id]/editions/[editionID]/page.js
@@ -86,7 +86,7 @@ export default async function Edition({ params, searchParams }) {
                 breadcrumbs={breadcrumbs}
                 showPanel={unpublishedVersion}
                 panelText="An unpublished version exists so cannot add new dataset version."
-                disbaleButton={!unpublishedVersion}
+                disableButton={!unpublishedVersion}
             /> 
             <div className="ons-grid ons-u-mt-xl">
                 <div className="ons-grid__col ons-col-4@m">


### PR DESCRIPTION
### What

Correctly set create button on edition overview.

How it currently looks in Sandbox:
<img width="767" height="397" alt="image" src="https://github.com/user-attachments/assets/238713de-b1b1-4c4d-9aae-b9694aee0fb2" />

How it looks after fix:
<img width="834" height="377" alt="image" src="https://github.com/user-attachments/assets/90592194-616a-4e0c-97a1-4df431036e22" />


### How to review

Navigate to an edition overview page that has unpublished versions attached and see change works as it should. 

### Who can review

Anyone
