### PR TITLE
Bugfix/construct release date client side

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -543,10 +543,33 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.1.tgz",
+      "integrity": "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.0",
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/runtime": {
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.7.1.tgz",
       "integrity": "sha512-PVtJr5CmLwYAU9PZDMITZoR5iAOShYREoR45EyyLrbntV50mdePTgUn4AmOw90Ifcj+x2kRjdzr1HP3RrNiHGA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
+      "integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -2506,6 +2529,19 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
+      "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.4.3",
+        "@emnapi/runtime": "^1.4.3",
+        "@tybys/wasm-util": "^0.10.0"
+      }
+    },
     "node_modules/@next/env": {
       "version": "16.1.7",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-16.1.7.tgz",
@@ -2948,6 +2984,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
       "license": "MIT"
@@ -3320,6 +3367,48 @@
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "dev": true
     },
+    "node_modules/@unrs/resolver-binding-android-arm-eabi": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.11.1.tgz",
+      "integrity": "sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-android-arm64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.11.1.tgz",
+      "integrity": "sha512-lCxkVtb4wp1v+EoN+HjIG9cIIzPkX5OtM03pQYkG+U5O/wL53LC4QbIeazgiKqluGeVEeBlZahHalCaBvU1a2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-darwin-arm64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.11.1.tgz",
+      "integrity": "sha512-gPVA1UjRu1Y/IsB/dQEsp2V1pm44Of6+LWvbLc9SDk1c2KhhDRDBUkQCYVWe6f26uJb3fOK8saWMgtX8IrMk3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
     "node_modules/@unrs/resolver-binding-darwin-x64": {
       "version": "1.11.1",
       "cpu": [
@@ -3330,6 +3419,219 @@
       "optional": true,
       "os": [
         "darwin"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-freebsd-x64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.11.1.tgz",
+      "integrity": "sha512-fqtGgak3zX4DCB6PFpsH5+Kmt/8CIi4Bry4rb1ho6Av2QHTREM+47y282Uqiu3ZRF5IQioJQ5qWRV6jduA+iGw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.11.1.tgz",
+      "integrity": "sha512-u92mvlcYtp9MRKmP+ZvMmtPN34+/3lMHlyMj7wXJDeXxuM0Vgzz0+PPJNsro1m3IZPYChIkn944wW8TYgGKFHw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.11.1.tgz",
+      "integrity": "sha512-cINaoY2z7LVCrfHkIcmvj7osTOtm6VVT16b5oQdS4beibX2SYBwgYLmqhBjA1t51CarSaBuX5YNsWLjsqfW5Cw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.11.1.tgz",
+      "integrity": "sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm64-musl": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.11.1.tgz",
+      "integrity": "sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.11.1.tgz",
+      "integrity": "sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.11.1.tgz",
+      "integrity": "sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.11.1.tgz",
+      "integrity": "sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.11.1.tgz",
+      "integrity": "sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-x64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.11.1.tgz",
+      "integrity": "sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-x64-musl": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.11.1.tgz",
+      "integrity": "sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-wasm32-wasi": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.11.1.tgz",
+      "integrity": "sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^0.2.11"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.11.1.tgz",
+      "integrity": "sha512-nRcz5Il4ln0kMhfL8S3hLkxI85BXs3o8EYoattsJNdsX4YUU89iOkVn7g0VHSRxFuVMdM4Q1jEpIId1Ihim/Uw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.11.1.tgz",
+      "integrity": "sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-win32-x64-msvc": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.11.1.tgz",
+      "integrity": "sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
       ]
     },
     "node_modules/@vitest/expect": {
@@ -3401,10 +3703,11 @@
       }
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.11.tgz",
-      "integrity": "sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==",
+      "version": "0.8.12",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.12.tgz",
+      "integrity": "sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       }
@@ -9989,14 +10292,16 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w=="
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
     },
     "node_modules/lodash-es": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
-      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg=="
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
+      "license": "MIT"
     },
     "node_modules/lodash.includes": {
       "version": "4.3.0",

--- a/src/app/actions/datasetEdition.js
+++ b/src/app/actions/datasetEdition.js
@@ -18,11 +18,7 @@ const editionWithVersionSchema = z.object({
     edition: z.string().min(1, { message: "Edition ID is required" }),
     edition_title: z.string().min(1, { message: "Edition title is required" }),
     quality_designation: z.string().min(1, { message: "Quality designation is required" }),
-    release_day: z.string().min(1, { message: "Day is required" }),
-    release_month: z.string().min(1, { message: "Month is required" }),
-    release_year: z.string().min(1, { message: "Year is required" }),
-    release_hour: z.string().min(1, { message: "Hour is required" }),
-    release_minutes: z.string().min(1, { message: "Minutes are required" }),
+    release_date: z.string().min(1, { message: "A release time and date is required" }),
     distributions: z.array(z.object({
         download_url: z.string(),
     })).min(1, { message: "A file upload is required" })

--- a/src/app/actions/datasetEdition.js
+++ b/src/app/actions/datasetEdition.js
@@ -18,6 +18,11 @@ const editionWithVersionSchema = z.object({
     edition: z.string().min(1, { message: "Edition ID is required" }),
     edition_title: z.string().min(1, { message: "Edition title is required" }),
     quality_designation: z.string().min(1, { message: "Quality designation is required" }),
+    release_day: z.string().min(1, { message: "Day is required" }),
+    release_month: z.string().min(1, { message: "Month is required" }),
+    release_year: z.string().min(1, { message: "Year is required" }),
+    release_hour: z.string().min(1, { message: "Hour is required" }),
+    release_minutes: z.string().min(1, { message: "Minutes are required" }),
     release_date: z.string().min(1, { message: "A release time and date is required" }),
     distributions: z.array(z.object({
         download_url: z.string(),

--- a/src/app/actions/datasetVersion.js
+++ b/src/app/actions/datasetVersion.js
@@ -11,6 +11,11 @@ import { z } from "zod";
  
 const versionSchema = z.object({
     quality_designation: z.string().min(1, { message: "Quality designation is required" }),
+    release_day: z.string().min(1, { message: "Day is required" }),
+    release_month: z.string().min(1, { message: "Month is required" }),
+    release_year: z.string().min(1, { message: "Year is required" }),
+    release_hour: z.string().min(1, { message: "Hour is required" }),
+    release_minutes: z.string().min(1, { message: "Minutes are required" }),
     release_date: z.string().min(1, { message: "A release time and date is required" }),
     distributions: z.array(z.object({
         download_url: z.string().min(1, { message: "A file upload is required" }),
@@ -28,7 +33,6 @@ const addUploadFileErrorMessage = (errors) => {
     }
     return errors;
 };
-
 
 // check and parse "MultiContent" (e.g. alerts and usuage notes) fields 
 const parseMutliContentField = (multiItem) => {
@@ -152,6 +156,11 @@ const getFormData = async (formData) => {
         version_id: formData.get("version-id"),
         edition_title: formData.get("edition-title"),
         quality_designation: formData.get("quality-designation-value"),
+        release_day: formData.get("release-date-day"),
+        release_month: formData.get("release-date-month"),
+        release_year: formData.get("release-date-year"),
+        release_hour: formData.get("release-date-hour"),
+        release_minutes: formData.get("release-date-minutes"),
         release_date: formData.get("release-date-value"),
         usage_notes: parsedUsageNotes,
         alerts: parsedAlerts,

--- a/src/app/actions/datasetVersion.js
+++ b/src/app/actions/datasetVersion.js
@@ -11,11 +11,7 @@ import { z } from "zod";
  
 const versionSchema = z.object({
     quality_designation: z.string().min(1, { message: "Quality designation is required" }),
-    release_day: z.string().min(1, { message: "Day is required" }),
-    release_month: z.string().min(1, { message: "Month is required" }),
-    release_year: z.string().min(1, { message: "Year is required" }),
-    release_hour: z.string().min(1, { message: "Hour is required" }),
-    release_minutes: z.string().min(1, { message: "Minutes are required" }),
+    release_date: z.string().min(1, { message: "A release time and date is required" }),
     distributions: z.array(z.object({
         download_url: z.string().min(1, { message: "A file upload is required" }),
     })).min(1, { message: "A file upload is required" })
@@ -33,16 +29,6 @@ const addUploadFileErrorMessage = (errors) => {
     return errors;
 };
 
-// check if any release date or time errors exists and merge them into one for time and date fieldset
-const mergeDateTimeErrors = (errors) => {
-    if (!errors) {
-        return;
-    } 
-    if (errors.release_day || errors.release_month || errors.release_year || errors.release_hour || errors.release_minutes) {
-        errors.release_date_time = ["A release time and date is required"];
-    }
-    return errors;
-};
 
 // check and parse "MultiContent" (e.g. alerts and usuage notes) fields 
 const parseMutliContentField = (multiItem) => {
@@ -166,19 +152,12 @@ const getFormData = async (formData) => {
         version_id: formData.get("version-id"),
         edition_title: formData.get("edition-title"),
         quality_designation: formData.get("quality-designation-value"),
-        release_day: formData.get("release-date-day"),
-        release_month: formData.get("release-date-month"),
-        release_year: formData.get("release-date-year"),
-        release_hour: formData.get("release-date-hour"),
-        release_minutes: formData.get("release-date-minutes"),
+        release_date: formData.get("release-date-value"),
         usage_notes: parsedUsageNotes,
         alerts: parsedAlerts,
         distributions: JSON.parse(formData.get("dataset-upload-value")),
-        release_date: null,
         type: "static",
     };
-
-    datasetVersion.release_date =  new Date(datasetVersion.release_year, datasetVersion.release_month - 1, datasetVersion.release_day, datasetVersion.release_hour, datasetVersion.release_minutes).toISOString();
     return datasetVersion;
 };
 
@@ -187,7 +166,6 @@ const handleFailedValidation = async (validation, datasetVersionSubmission) => {
     actionResponse.success = validation.success;
     actionResponse.errors = validation.error.flatten().fieldErrors;
     actionResponse.errors = addUploadFileErrorMessage(actionResponse.errors);
-    actionResponse.errors = mergeDateTimeErrors(actionResponse.errors);
     actionResponse.submission = datasetVersionSubmission;
     logInfo("failed dataset version validation", null, null);
     return actionResponse;

--- a/src/components/date-time/DateTimePicker.js
+++ b/src/components/date-time/DateTimePicker.js
@@ -44,6 +44,7 @@ export default function DateTimePicker(props) {
                 maxLength={2}
                 type="number"
                 value={day}
+                name={"release-date-day"}
                 dataTestId={`${sanitisedDataTestId}-day`}
             />
 
@@ -60,6 +61,7 @@ export default function DateTimePicker(props) {
                 maxLength={2}
                 type="number"
                 value={month}
+                name={"release-date-month"}
                 dataTestId={`${sanitisedDataTestId}-month`}
             />
 
@@ -76,6 +78,7 @@ export default function DateTimePicker(props) {
                 maxLength={4}
                 type="number"
                 value={year}
+                name={"release-date-year"}
                 dataTestId={`${sanitisedDataTestId}-year`}
             />
 
@@ -92,6 +95,7 @@ export default function DateTimePicker(props) {
                 maxLength={2}
                 type="number"
                 value={hour}
+                name={"release-date-hour"}
                 dataTestId={`${sanitisedDataTestId}-hour`}
             />
 
@@ -108,13 +112,14 @@ export default function DateTimePicker(props) {
                 maxLength={2}
                 type="number"
                 value={minutes}
+                name={"release-date-minutes"}
                 dataTestId={`${sanitisedDataTestId}-minutes`}
             />
 
             <input
                 id={`${sanitisedId}-value`}
                 data-testid={`${sanitisedDataTestId}-value`}
-                name="release-date-value"
+                name={"release-date-value"}
                 type="hidden"
                 value={buildReleaseDateValue()}
             />

--- a/src/components/date-time/DateTimePicker.js
+++ b/src/components/date-time/DateTimePicker.js
@@ -11,20 +11,20 @@ export default function DateTimePicker(props) {
     const [minutes, setMinutes] = useState(releaseDate?.minutes || "");
 
     const buildReleaseDateValue = () => {
-    if (!day || !month || !year || !hour || !minutes) {
-        return "";
-    }
+        if (!day || !month || !year || !hour || !minutes) {
+            return "";
+        }
 
-    const date = new Date(
-        parseInt(year, 10),
-        parseInt(month, 10) - 1,
-        parseInt(day, 10),
-        parseInt(hour, 10),
-        parseInt(minutes, 10)
-    );
+        const date = new Date(
+            parseInt(year, 10),
+            parseInt(month, 10) - 1,
+            parseInt(day, 10),
+            parseInt(hour, 10),
+            parseInt(minutes, 10)
+        );
 
-    return isNaN(date.getTime()) ? "" : date.toISOString();
-};
+        return isNaN(date.getTime()) ? "" : date.toISOString();
+    };
 
     const sanitisedId = sanitiseString(props.id);
     const sanitisedDataTestId = sanitiseString(props.dataTestId);

--- a/src/components/date-time/DateTimePicker.js
+++ b/src/components/date-time/DateTimePicker.js
@@ -44,7 +44,6 @@ export default function DateTimePicker(props) {
                 maxLength={2}
                 type="number"
                 value={day}
-                name={"release-date-day"}
                 dataTestId={`${sanitisedDataTestId}-day`}
             />
 
@@ -61,7 +60,6 @@ export default function DateTimePicker(props) {
                 maxLength={2}
                 type="number"
                 value={month}
-                name={"release-date-month"}
                 dataTestId={`${sanitisedDataTestId}-month`}
             />
 
@@ -78,7 +76,6 @@ export default function DateTimePicker(props) {
                 maxLength={4}
                 type="number"
                 value={year}
-                name={"release-date-year"}
                 dataTestId={`${sanitisedDataTestId}-year`}
             />
 
@@ -95,7 +92,6 @@ export default function DateTimePicker(props) {
                 maxLength={2}
                 type="number"
                 value={hour}
-                name={"release-date-hour"}
                 dataTestId={`${sanitisedDataTestId}-hour`}
             />
 
@@ -112,7 +108,6 @@ export default function DateTimePicker(props) {
                 maxLength={2}
                 type="number"
                 value={minutes}
-                name={"release-date-minutes"}
                 dataTestId={`${sanitisedDataTestId}-minutes`}
             />
 

--- a/src/components/date-time/DateTimePicker.js
+++ b/src/components/date-time/DateTimePicker.js
@@ -10,6 +10,22 @@ export default function DateTimePicker(props) {
     const [hour, setHour] = useState(releaseDate?.hour || "");
     const [minutes, setMinutes] = useState(releaseDate?.minutes || "");
 
+    const buildReleaseDateValue = () => {
+    if (!day || !month || !year || !hour || !minutes) {
+        return "";
+    }
+
+    const date = new Date(
+        parseInt(year, 10),
+        parseInt(month, 10) - 1,
+        parseInt(day, 10),
+        parseInt(hour, 10),
+        parseInt(minutes, 10)
+    );
+
+    return isNaN(date.getTime()) ? "" : date.toISOString();
+};
+
     const sanitisedId = sanitiseString(props.id);
     const sanitisedDataTestId = sanitiseString(props.dataTestId);
 
@@ -91,10 +107,21 @@ export default function DateTimePicker(props) {
                 }}
                 onChange={e => setMinutes(e.target.value)}
                 width="3"
-                type="input"
+                min={0}
+                max={59}
+                maxLength={2}
+                type="number"
                 value={minutes}
                 name={"release-date-minutes"}
                 dataTestId={`${sanitisedDataTestId}-minutes`}
+            />
+
+            <input
+                id={`${sanitisedId}-value`}
+                data-testid={`${sanitisedDataTestId}-value`}
+                name="release-date-value"
+                type="hidden"
+                value={buildReleaseDateValue()}
             />
         </div>
     );
@@ -106,7 +133,7 @@ export default function DateTimePicker(props) {
                 legend={props.legend}
                 description={props.description}
                 dataTestId={`fieldset-${sanitisedDataTestId}`}
-                error={(props.errors && props.errors.release_date_time) ? {id:'release-date-time-error', text: props.errors.release_date_time} : null} 
+                error={(props.errors && props.errors.release_date) ? {id:'release-date-error', text: props.errors.release_date} : null} 
             >
                 {fields}
             </Fieldset>

--- a/src/components/date-time/DateTimePicker.test.js
+++ b/src/components/date-time/DateTimePicker.test.js
@@ -23,6 +23,9 @@ describe("DateTimerPicker", () => {
 
         const minutes = screen.getByTestId("release-date-minutes");
         expect(minutes).toBeInTheDocument();
+
+        const hiddenReleaseDate = screen.getByTestId("release-date-value");
+        expect(hiddenReleaseDate).toBeInTheDocument();
     });
 
     it("renders correctly when existing date is passed in", () => {
@@ -31,16 +34,19 @@ describe("DateTimerPicker", () => {
         expect(day.value).toBe("25");
 
         const month = screen.getByTestId("release-date-month");
-        expect(month).toBeInTheDocument("2");
+        expect(month.value).toBe("02");
 
         const year = screen.getByTestId("release-date-year");
-        expect(year).toBeInTheDocument("2025");
+        expect(year.value).toBe("2025");
 
         const hour = screen.getByTestId("release-date-hour");
-        expect(hour).toBeInTheDocument("9");
+        expect(hour.value).toBe("09");
 
         const minutes = screen.getByTestId("release-date-minutes");
-        expect(minutes).toBeInTheDocument("30");
+        expect(minutes.value).toBe("30");
+
+        const hiddenReleaseDate = screen.getByTestId("release-date-value");
+        expect(hiddenReleaseDate.value).toBe("2025-02-25T09:30:00.000Z");
     });
 
     it("onChange handler updates day state", () => {

--- a/src/components/form/version/VersionFields.js
+++ b/src/components/form/version/VersionFields.js
@@ -27,7 +27,7 @@ export default function VersionFields(props) {
                 id="release-date"
                 dataTestId="release-date"
                 legend="Release date and time"
-                description="For example, 31 3 1980 09 30"
+                description="For example, 31 03 1980 09 30"
                 errors={props.errors}
                 releaseDate={props.fieldValues?.release_date}
             />

--- a/src/utils/datetime/datetime.js
+++ b/src/utils/datetime/datetime.js
@@ -31,10 +31,13 @@ export function ISOToDMYMHValues(dateString) {
             return null;
         }
 
-        let minutes = date.getMinutes();
-        if (minutes < 9) { minutes = "0" + minutes; }
+        const day = String(date.getDate()).padStart(2, '0');
+        const month = String(date.getMonth() + 1).padStart(2, '0');
+        const year = date.getFullYear();
+        const hours = String(date.getHours()).padStart(2, '0');
+        const minutes = String(date.getMinutes()).padStart(2, '0');
 
-        return {day: date.getDate(), month: date.getMonth() + 1, year: date.getFullYear(), minutes: minutes, hour: date.getHours()};
+        return {day: day, month: month, year: year, minutes: minutes, hour: hours};
     } catch (error) {
         logError("error converting ISO date to day, month, year, minutes, hours values", null, null, error);
         return null;

--- a/src/utils/datetime/datetime.test.js
+++ b/src/utils/datetime/datetime.test.js
@@ -35,11 +35,11 @@ describe('formatDate', () => {
 describe('ISOToDMYMHValues', () => {
     test('should return correct values for valid date string', () => {
         const result = ISOToDMYMHValues('2000-01-01T07:00:00.000Z');
-        expect(result.day).toBe(1);
-        expect(result.month).toBe(1);
+        expect(result.day).toBe('01');
+        expect(result.month).toBe('01');
         expect(result.year).toBe(2000);
         expect(result.minutes).toBe('00');
-        expect(result.hour).toBe(7);
+        expect(result.hour).toBe('07');
     });
 
     test('should return null when called with no arguments', () => {


### PR DESCRIPTION
### What

Ticket: https://officefornationalstatistics.atlassian.net/browse/DIS-4394

- Resolve bug where the release date input would show +1 hour ahead on the edit form
- This was happening as the `new Date()` constructor was being called server side and the server is in UTC by default. A user in BST would input 7am and this would be sent as 7am UTC therefore being displayed as 8am on the edit form as the date in converted to BST when viewing.
- To fix this the release date is now constructed client-side before sending the data to the API. (Entering 7am BST will send 6am UTC to the database)

### How to review

- Create an edition/version and then navigate to the version edit form. The release date displayed on the form should be the same as what was entered at creation.
- Run `dis-data-admin-ui` within the `dataset-catalogue` stack to verify as the container clock is UTC and your machine will be on BST.

### Who can review

- Anyone
