### PR TITLE
Make topics component more robust and use included rather than excluded topics

### DIFF
--- a/src/components/topics/Topics.js
+++ b/src/components/topics/Topics.js
@@ -148,13 +148,14 @@ export default function Topics({ listOfAllTopics, preSelectedTopics, topicsError
     };
 
     const mapTopicsToTopicSelector = (topics) => {
+        console.log("HEllo")
         if (!topics) return [];
         return topics.map(topic => ({
             ...topic,
-            isOpen: topic.subtopics?.some((sub) =>
+            isOpen: topic?.subtopics?.some((sub) =>
                 selectedTopics.some((t) => getTopicID(t) === getTopicID(sub))
             ) ?? false,
-            body: topic.subtopics?.map(sub => (
+            body: topic?.subtopics?.map(sub => (
                 <span
                     className="ons-checkbox ons-checkbox--no-border ons-u-mb-xs"
                     data-testid={`dataset-series-topic-${sub.id}-checkbox`}

--- a/src/components/topics/Topics.js
+++ b/src/components/topics/Topics.js
@@ -148,7 +148,6 @@ export default function Topics({ listOfAllTopics, preSelectedTopics, topicsError
     };
 
     const mapTopicsToTopicSelector = (topics) => {
-        console.log("HEllo")
         if (!topics) return [];
         return topics.map(topic => ({
             ...topic,

--- a/src/components/topics/topicsData.js
+++ b/src/components/topics/topicsData.js
@@ -10,25 +10,6 @@ const EXCLUDED_TOPIC_SLUGS = new Set([
     "surverys" // Our studies
 ]);
 
-// Subtopic ID's that we don't want to appear in Topic Selector UI
-const EXCLUDED_SUBTOPIC_IDS = new Set([
-    "1678", // Population and migration
-    "1792", // Cultural identity
-    "1831", // Business
-    "2364", // Household characteristics
-    "3258", // Personal and household finances
-    "4261", // Elections
-    "4573", // Changes to business
-    "6462", // People in work
-    "7273", // People not in work
-    "8268", // Government, public sector and taxes
-    "8533", // Regional accounts
-    "8629", // National accounts
-    "8636", // Births, deaths and marriages"
-    "8725", // Economic output and productivity
-    "9559", // Health and social care
-]);
-
 /**
  * Returns mapped topics with subtopics
  *
@@ -76,8 +57,9 @@ const getSubTopics = async (reqCfg, url) => {
                 nested = await getSubTopics(reqCfg, subTubTopicURL.pathname.substring(3));
             }
 
-            // Excluded subtopics are omitted and their children are added into list
-            if (EXCLUDED_SUBTOPIC_IDS.has(String(st.id))) {
+            // Subtopics that expose nested subtopics metadata are omitted
+            // and their children are flattened into the returned list.
+            if (st?.links?.subtopics?.href && Array.isArray(st?.subtopics_ids)) {
                 return nested;
             }
             return [mapTopic(st, null), ...nested];

--- a/src/components/topics/topicsData.js
+++ b/src/components/topics/topicsData.js
@@ -37,7 +37,6 @@ const EXCLUDED_SUBTOPIC_IDS = new Set([
  */
 export const getAllTopics = async (reqCfg) => {
     const topics = await httpGet(reqCfg, "/topics");
-    console.log("TOPICS REQUEST:", topics)
     if (topics.ok != null && !topics.ok || topics?.items.length === 0) return [];
 
     const includedItems = topics.items.filter((topic) => {

--- a/src/components/topics/topicsData.js
+++ b/src/components/topics/topicsData.js
@@ -1,10 +1,13 @@
 import { httpGet } from "@/utils/request/request";
 
-// Topic ID's that we don't want to appear in Topic Selector UI
-const EXCLUDED_TOPIC_IDS = new Set([
-    "5829", // About us
-    "6537", // Methodolgy
-    "8925", // Help
+// Topic slug's that we don't want to appear in Topic Selector UI
+// note: slug doesn't always match title
+const EXCLUDED_TOPIC_SLUGS = new Set([
+    "aboutus", // About us
+    "help", // Help
+    "methodology", // Methodolgy
+    "news", // Media
+    "surverys" // Our studies
 ]);
 
 // Subtopic ID's that we don't want to appear in Topic Selector UI
@@ -34,11 +37,12 @@ const EXCLUDED_SUBTOPIC_IDS = new Set([
  */
 export const getAllTopics = async (reqCfg) => {
     const topics = await httpGet(reqCfg, "/topics");
+    console.log("TOPICS REQUEST:", topics)
     if (topics.ok != null && !topics.ok || topics?.items.length === 0) return [];
 
     const includedItems = topics.items.filter((topic) => {
         const t = topic.current || topic.next || topic;
-        return !EXCLUDED_TOPIC_IDS.has(String(t.id));
+        return !EXCLUDED_TOPIC_SLUGS.has(String(t.slug));
     });
 
     return Promise.all(

--- a/src/components/topics/topicsData.js
+++ b/src/components/topics/topicsData.js
@@ -1,13 +1,12 @@
 import { httpGet } from "@/utils/request/request";
 
-// Topic slug's that we don't want to appear in Topic Selector UI
-// note: slug doesn't always match title
-const EXCLUDED_TOPIC_SLUGS = new Set([
-    "aboutus", // About us
-    "help", // Help
-    "methodology", // Methodolgy
-    "news", // Media
-    "surverys" // Our studies
+// Topic slug's that we want to appear in Topic Selector UI
+const INCLUDE_TOPIC_SLUGS = new Set([
+    "businessindustryandtrade", // Business, industry and trade
+    "census", // Census
+    "economy", // Economy
+    "employmentandlabourmarket", // Employment and labour market
+    "peoplepopulationandcommunity", // People, population and community
 ]);
 
 /**
@@ -22,7 +21,7 @@ export const getAllTopics = async (reqCfg) => {
 
     const includedItems = topics.items.filter((topic) => {
         const t = topic.current || topic.next || topic;
-        return !EXCLUDED_TOPIC_SLUGS.has(String(t.slug));
+        return INCLUDE_TOPIC_SLUGS.has(String(t.slug));
     });
 
     return Promise.all(

--- a/src/components/topics/topicsData.test.js
+++ b/src/components/topics/topicsData.test.js
@@ -37,6 +37,7 @@ describe("getAllTopics", () => {
                 {
                     id: "2945",
                     title: "Business",
+                    slug: "businessindustryandtrade",
                     links: {
                         subtopics: { href: subtopicsHref },
                     },
@@ -75,6 +76,7 @@ describe("getAllTopics", () => {
                 {
                     id: "1",
                     title: "Topic",
+                    slug: "economy",
                     links: { subtopics: { href: subtopicsHref } },
                 },
             ],
@@ -98,6 +100,7 @@ describe("getAllTopics", () => {
                 {
                     id: "1",
                     title: "Topic",
+                    slug: "economy",
                     links: {
                         subtopics: { href: "https://api.example.com/v1/topics/1/subtopics" },
                     },
@@ -146,6 +149,7 @@ describe("getAllTopics", () => {
                 {
                     id: "1",
                     title: "Topic",
+                    slug: "economy",
                     links: {
                         subtopics: { href: "https://api.example.com/v1/topics/1/subtopics" },
                     },
@@ -183,7 +187,7 @@ describe("getAllTopics", () => {
         expect(httpGet).toHaveBeenNthCalledWith(3, reqCfg, "/topics/2/subtopics");
     });
 
-    it("excludes topic when ID matches exlcude list and does not fetch subtopics for it", async () => {
+    it("includes only topics whose slug matches include list and does not fetch subtopics for excluded slugs", async () => {
         const includedSubtopicsHref = "https://api.example.com/v1/topics/2945/subtopics";
 
         httpGet.mockResolvedValueOnce({
@@ -201,7 +205,7 @@ describe("getAllTopics", () => {
                 {
                     id: "2945",
                     title: "Business",
-                    slug: "business",
+                    slug: "businessindustryandtrade",
                     links: { subtopics: { href: includedSubtopicsHref } },
                 },
             ],

--- a/src/components/topics/topicsData.test.js
+++ b/src/components/topics/topicsData.test.js
@@ -140,6 +140,49 @@ describe("getAllTopics", () => {
         expect(httpGet).toHaveBeenNthCalledWith(3, reqCfg, "/topics/2/subtopics");
     });
 
+    it("omits parent subtopic when it has subtopics metadata and flattens children", async () => {
+        httpGet.mockResolvedValueOnce({
+            items: [
+                {
+                    id: "1",
+                    title: "Topic",
+                    links: {
+                        subtopics: { href: "https://api.example.com/v1/topics/1/subtopics" },
+                    },
+                },
+            ],
+        });
+        httpGet.mockResolvedValueOnce({
+            items: [
+                {
+                    id: "2",
+                    title: "Wrapper subtopic",
+                    subtopics_ids: ["3"],
+                    links: {
+                        subtopics: { href: "https://api.example.com/v1/topics/2/subtopics" },
+                    },
+                },
+            ],
+        });
+        httpGet.mockResolvedValueOnce({
+            items: [{ id: "3", title: "Nested subtopic" }],
+        });
+
+        const result = await getAllTopics(reqCfg);
+
+        expect(result).toEqual([
+            {
+                id: "1",
+                label: "Topic",
+                subtopics: [{ id: "3", label: "Nested subtopic" }],
+            },
+        ]);
+        expect(httpGet).toHaveBeenCalledTimes(3);
+        expect(httpGet).toHaveBeenNthCalledWith(1, reqCfg, "/topics");
+        expect(httpGet).toHaveBeenNthCalledWith(2, reqCfg, "/topics/1/subtopics");
+        expect(httpGet).toHaveBeenNthCalledWith(3, reqCfg, "/topics/2/subtopics");
+    });
+
     it("excludes topic when ID matches exlcude list and does not fetch subtopics for it", async () => {
         const includedSubtopicsHref = "https://api.example.com/v1/topics/2945/subtopics";
 
@@ -148,6 +191,7 @@ describe("getAllTopics", () => {
                 {
                     id: "5829",
                     title: "About us",
+                    slug: "aboutus",
                     links: {
                         subtopics: {
                             href: "https://api.example.com/v1/topics/5829/subtopics",
@@ -157,6 +201,7 @@ describe("getAllTopics", () => {
                 {
                     id: "2945",
                     title: "Business",
+                    slug: "business",
                     links: { subtopics: { href: includedSubtopicsHref } },
                 },
             ],

--- a/tests/mocks/topics.mjs
+++ b/tests/mocks/topics.mjs
@@ -2,7 +2,8 @@ export const topicList = {
     "items": [
         {
             "id": "1000",
-            "title": "Business",
+            "title": "Business, industry and trade",
+            "slug": "businessindustryandtrade",
             "links": {
                 "subtopics": {
                     "href": "https://api.dp.aws.onsdigital.uk/v1/topics/1000/subtopics"
@@ -24,6 +25,7 @@ export const topicList = {
         {
             "id": "2000",
             "title": "Census",
+            "slug": "census",
             "links": {
                 "subtopics": {
                     "href": "https://api.dp.aws.onsdigital.uk/v1/topics/2000/subtopics"


### PR DESCRIPTION
### What

Make topics component more robust and use included rather than excluded topics. Using included rather than excluded prevents any new top level topics being added and causing breakages or other issues within the component

### How to review

Sanity check and test topics

### Who can review

Anyone
