### PR TITLE
rewrite existing download_url's to be relative within upload component

### DIFF
--- a/src/components/file-upload/ResumableFileUpload.js
+++ b/src/components/file-upload/ResumableFileUpload.js
@@ -7,6 +7,7 @@ import bindFileUploadInput from "./bind";
 
 import { TextInput, Summary } from "author-design-system-react";
 import { mapUploadedFilesSummary } from "@/components/design-system/summary-mapper";
+import { getDistributionPath } from "@/utils/url/url";
 
 const UUID_EXTRACT_PATTERN = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i;
 
@@ -14,11 +15,23 @@ const PROGRESS_BAR_STYLE = {
     width: "20rem",
 };
 
+// The dataset-api returns absolute download URLs, but we need to send relative paths.
+const normalizeUploadedFiles = (uploadedFiles = []) => {
+    return uploadedFiles.map((file) => {
+        const normalizedDownloadURL = getDistributionPath(file?.download_url);
+
+        return {
+            ...file,
+            download_url: normalizedDownloadURL || file?.download_url,
+        };
+    });
+};
+
 export default function ResumableFileUpload({ id = "dataset-upload", uploadBaseURL, label = "File upload", description, validationError, uploadedFiles, accessToken }) {
     const [showProgressBar, setShowProgressBar] = useState(false);
     const [progress, setProgress] = useState(0);
     const [error, setError] = useState(validationError || null);
-    const [files, setFiles] = useState(uploadedFiles || []);
+    const [files, setFiles] = useState(() => normalizeUploadedFiles(uploadedFiles || []));
 
     const handleFileStart = useCallback(() => {
         setShowProgressBar(true);

--- a/src/components/file-upload/ResumableFileUpload.test.js
+++ b/src/components/file-upload/ResumableFileUpload.test.js
@@ -8,7 +8,10 @@ jest.mock("uuid", () => ({
 
 import ResumableFileUpload from "./ResumableFileUpload";
 
-const uploadedFile = [{title: "Test dataset title", format: "csv", download_url: "12345678-1234-1234-1234-123456789012/download.csv"}];
+const uploadedFiles = [
+    { title: "Relative dataset title", format: "csv", download_url: "12345678-1234-1234-1234-123456789012/relative.csv" },
+    { title: "Absolute dataset title", format: "csv", download_url: "http://localhost:23600/downloads/files/12345678-1234-1234-1234-123456789012/absolute.csv" }
+];
 
 describe("ResumableFileUpload", () => {
     it("renders correctly in ready state", () => {
@@ -28,23 +31,25 @@ describe("ResumableFileUpload", () => {
     });
 
     it("renders correctly when a file has been uploaded", () => {
-        render(<ResumableFileUpload uploadedFiles={uploadedFile}/>);
-        expect(screen.getByTestId("dataset-upload-value").value).toBe("[{\"title\":\"Test dataset title\",\"format\":\"csv\",\"download_url\":\"12345678-1234-1234-1234-123456789012/download.csv\"}]");
-        expect(screen.getAllByText(/Test dataset title/i)[0]).toBeInTheDocument();
-        expect(screen.getByTestId("action-link-test-dataset-title")).toBeInTheDocument();
+        render(<ResumableFileUpload uploadedFiles={uploadedFiles}/>);
+        expect(screen.getByTestId("dataset-upload-value").value).toBe("[{\"title\":\"Relative dataset title\",\"format\":\"csv\",\"download_url\":\"12345678-1234-1234-1234-123456789012/relative.csv\"},{\"title\":\"Absolute dataset title\",\"format\":\"csv\",\"download_url\":\"12345678-1234-1234-1234-123456789012/absolute.csv\"}]");
+        expect(screen.getAllByText(/Relative dataset title/i)[0]).toBeInTheDocument();
+        expect(screen.getAllByText(/Absolute dataset title/i)[0]).toBeInTheDocument();
+        expect(screen.getByTestId("action-link-relative-dataset-title")).toBeInTheDocument();
+        expect(screen.getByTestId("action-link-absolute-dataset-title")).toBeInTheDocument();
     });
 
     it("remove file link works correctly", () => {
-        render(<ResumableFileUpload uploadedFiles={uploadedFile}/>);
+        render(<ResumableFileUpload uploadedFiles={uploadedFiles}/>);
         const hiddenInput = screen.getByTestId("dataset-upload-value");
-        expect(hiddenInput.value).toBe("[{\"title\":\"Test dataset title\",\"format\":\"csv\",\"download_url\":\"12345678-1234-1234-1234-123456789012/download.csv\"}]");
+        expect(hiddenInput.value).toBe("[{\"title\":\"Relative dataset title\",\"format\":\"csv\",\"download_url\":\"12345678-1234-1234-1234-123456789012/relative.csv\"},{\"title\":\"Absolute dataset title\",\"format\":\"csv\",\"download_url\":\"12345678-1234-1234-1234-123456789012/absolute.csv\"}]");
 
-        const removeButton = screen.getByTestId("action-link-test-dataset-title");
+        const removeButton = screen.getByTestId("action-link-relative-dataset-title");
         fireEvent.click(removeButton);
 
-        // distrubution (upload) value is reset
-        expect(hiddenInput.value).toBe("[]");
+        // one file remains after removal
+        expect(hiddenInput.value).toBe("[{\"title\":\"Absolute dataset title\",\"format\":\"csv\",\"download_url\":\"12345678-1234-1234-1234-123456789012/absolute.csv\"}]");
 
-        expect(screen.getByTestId("dataset-upload-no-files-uploaded-text")).toBeInTheDocument();
+        expect(screen.queryByTestId("dataset-upload-no-files-uploaded-text")).not.toBeInTheDocument();
     });
 });


### PR DESCRIPTION
### What

Ticket: https://officefornationalstatistics.atlassian.net/browse/DIS-4950

- When the upload component is mounted, all existing file uploads should have their `download_url` rewritten to be relative. This is needed since the dataset-api will return absolute URLs but when we submit a `POST/PUT` request, only the relative path is required.

### How to review

1. Create a dataset version
2. Check that the `distribution.download_url` within the `versions` collection in the `datasets` database is stored as relative.
3. Edit the version by adding another file upload and ensure the distributions within the database record still have relative links

### Who can review

- Anyone
