### PR TITLE
Bug fix: persist sort of migration jobs list

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,5 +1,6 @@
 import { defineConfig } from "eslint/config";
 import js from "@eslint/js";
+import globals from "globals";
 import nextVitals from "eslint-config-next/core-web-vitals";
 
 const eslintConfig = defineConfig([
@@ -15,6 +16,12 @@ const eslintConfig = defineConfig([
             "**/**.test.**",
             "coverage/**",
         ],
+    },
+    {
+        files: ["jest.setup.js", "jest.config.js"],
+        languageOptions: {
+            globals: globals.jest,
+        },
     },
     {
         files: ["**/*.{js,jsx,mjs,cjs}"],

--- a/jest.config.js
+++ b/jest.config.js
@@ -147,7 +147,7 @@ const config = {
     // setupFiles: [],
 
     // A list of paths to modules that run some code to configure or set up the testing framework before each test
-    // setupFilesAfterEnv: [],
+    setupFilesAfterEnv: ["<rootDir>/jest.setup.js"],
 
     // The number of seconds after which a test is considered as slow and reported as such in the results.
     // slowTestThreshold: 5,

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,12 @@
+jest.mock("next/navigation", () => ({
+    useRouter: jest.fn(() => ({
+        push: jest.fn(),
+        replace: jest.fn(),
+        refresh: jest.fn(),
+        back: jest.fn(),
+        forward: jest.fn(),
+        prefetch: jest.fn(),
+    })),
+    usePathname: jest.fn(() => "/"),
+    useSearchParams: jest.fn(() => new URLSearchParams()),
+}));

--- a/src/app/migration/page.js
+++ b/src/app/migration/page.js
@@ -55,7 +55,7 @@ export default async function MigrationList({ searchParams }) {
                         </div>
                     </div>
                 </div>
-                <Table contents={mappedTable} classes="ons-u-mt-m" dataTestId="migration-list-table" />
+                <Table contents={mappedTable} classes="ons-u-mt-m" dataTestId="migration-list-table" sortBy={pageParams.sort}/>
                 <Pagination
                     totalNumberOfPages={totalNumberOfPages}
                     currentPage={currentPage}

--- a/src/app/migration/page.js
+++ b/src/app/migration/page.js
@@ -2,7 +2,7 @@ import { cookies } from "next/headers";
 
 import { httpGet, SSRequestConfig } from "@/utils/request/request";
 
-import { Panel } from "@/components/design-system/DesignSystem";
+import { BoxContainer, Panel } from "@/components/design-system/DesignSystem";
 
 import LinkButton from "@/components/link-button/LinkButton";
 import Table from "@/components/table/Table";
@@ -68,6 +68,15 @@ export default async function MigrationList({ searchParams }) {
         <>
             <div className="ons-grid ons-u-mt-l ons-u-mb-l">
                 <div className="ons-grid__col ons-col-4@m ons-u-pr-m">
+                    <BoxContainer
+                        borderColor="ons-color-grey-15"
+                        borderWidth={1}
+                        classes="ons-grid__col ons-u-pl-no"
+                        id="box-container"
+                        title="Search and filter"
+                    >
+                        <p className="ons-u-mt-m">Search and filters coming soon</p>
+                    </BoxContainer>
                 </div>
                 <div className="ons-grid__col ons-col-8@m">
                     {renderListArea()}

--- a/src/components/form/series/seriesForm.test.js
+++ b/src/components/form/series/seriesForm.test.js
@@ -3,13 +3,6 @@ import { render, screen, fireEvent } from "@testing-library/react"
 import SeriesForm from "./SeriesForm"
 import { datasetList } from "../../../../tests/mocks/datasets.mjs";
 
-import { useRouter } from "next/navigation";
-
-jest.mock("next/navigation", () => ({ 
-    useRouter: jest.fn().mockReturnValue({ 
-        push: jest.fn(), 
-    }), 
-}));
 
 describe("Series Form", () => {
     const listOfAllTopics = [

--- a/src/components/table/Table.js
+++ b/src/components/table/Table.js
@@ -1,54 +1,63 @@
 "use client";
 
 import { useRouter, usePathname, useSearchParams } from "next/navigation";
-import { useState, useEffect } from "react";
+import { useMemo } from "react";
 import { sanitiseString } from "author-design-system-react";
 
+function parseSortBy(sortBy) {
+    if (!sortBy) {
+        return null;
+    }
+    const [rowIndexStr, direction] = sortBy.split(":");
+    const rowIndex = Number(rowIndexStr);
+    if (Number.isNaN(rowIndex) || (direction !== "asc" && direction !== "desc")) {
+        return null;
+    }
+    return { rowIndex, order: direction };
+}
+
+function sortRows(rows, rowIndex, direction) {
+    const isDescending = direction === "desc";
+    return [...rows].sort((a, b) => {
+        const sortValueA = a.columns[rowIndex]?.sortValue ?? "";
+        const sortValueB = b.columns[rowIndex]?.sortValue ?? "";
+
+        if (isDescending) {
+            return sortValueB.localeCompare(sortValueA);
+        }
+        return sortValueA.localeCompare(sortValueB);
+    });
+}
+
 export default function Table({ contents, caption, classes, dataTestId, noResultsText = "No data available", sortBy = null }) {
-    const [rows, setRows] = useState(contents?.body?.rows || []);
-    const [sorted, setSorted] = useState();
     const router = useRouter();
     const pathname = usePathname();
     const params = useSearchParams();
 
-    useEffect(() => {
-        if (!sortBy) { 
-            // eslint-disable-next-line react-hooks/set-state-in-effect
-            setRows(contents?.body?.rows || []); 
-        } else {
-            const sortByStr = sortBy.split(":");
-            const sortIndex = sortByStr[0];
-            const sortDirection = sortByStr[1];
-            doSort(sortIndex, sortDirection)
+    const activeSort = useMemo(() => parseSortBy(sortBy), [sortBy]);
+
+    const rows = useMemo(() => {
+        const sourceRows = contents?.body?.rows || [];
+        if (!activeSort) {
+            return sourceRows;
         }
-    }, [contents]);
+        return sortRows(sourceRows, activeSort.rowIndex, activeSort.order);
+    }, [contents?.body?.rows, activeSort]);
 
     const sanitisedDataTestId = sanitiseString(dataTestId);
+
+    const getNextSortDirection = (columnIndex) => {
+        if (activeSort?.rowIndex === columnIndex) {
+            return activeSort.order === "asc" ? "desc" : "asc";
+        }
+        return "asc";
+    };
 
     const handleSortClick = (rowIndex, sortDirection) => {
         const allParams = new URLSearchParams(Array.from(params.entries()));
         allParams.set("sort", `${rowIndex}:${sortDirection}`);
         router.replace(`${pathname}?${allParams.toString()}`);
-    }
-
-    const doSort = (rowIndex, sortDirection) => {
-        const isDescending = sortDirection === "desc";
-        const sortColumnIndex = Number(rowIndex);
-        const sourceRows = contents?.body?.rows || [];
-        
-        const sortedRows = [...sourceRows].sort((a, b) => {
-            const sortValueA = a.columns[sortColumnIndex]?.sortValue || "";
-            const sortValueB = b.columns[sortColumnIndex]?.sortValue || "";
-            
-            if (isDescending) {
-                return sortValueB.localeCompare(sortValueA);
-            }
-            return sortValueA.localeCompare(sortValueB);
-        });
-        
-        setRows(sortedRows);
-        setSorted({ rowIndex: sortColumnIndex, order: isDescending ? "desc" : "asc" });
-    }
+    };
 
     const renderTableHeader = () => {
         return (
@@ -66,7 +75,7 @@ export default function Table({ contents, caption, classes, dataTestId, noResult
                                         data-testid={`${sanitisedDataTestId}-sort-button-${sanitisedHeaderLabel}`} 
                                         className="ons-table__sort-button" 
                                         onClick={() => {
-                                            handleSortClick(index, index === sorted?.rowIndex ? sorted?.order === "asc" ? "desc" : "asc" : "asc")
+                                            handleSortClick(index, getNextSortDirection(index));
                                         }}
                                     >
                                         {header.label}

--- a/src/components/table/Table.js
+++ b/src/components/table/Table.js
@@ -1,41 +1,54 @@
 "use client";
 
+import { useRouter, usePathname, useSearchParams } from "next/navigation";
 import { useState, useEffect } from "react";
 import { sanitiseString } from "author-design-system-react";
 
-export default function Table({ contents, caption, classes, dataTestId, noResultsText = "No data available" }) {
+export default function Table({ contents, caption, classes, dataTestId, noResultsText = "No data available", sortBy = null }) {
     const [rows, setRows] = useState(contents?.body?.rows || []);
     const [sorted, setSorted] = useState();
+    const router = useRouter();
+    const pathname = usePathname();
+    const params = useSearchParams();
 
     useEffect(() => {
-        // eslint-disable-next-line react-hooks/set-state-in-effect
-        setRows(contents?.body?.rows || []);
+        if (!sortBy) { 
+            // eslint-disable-next-line react-hooks/set-state-in-effect
+            setRows(contents?.body?.rows || []); 
+        } else {
+            const sortByStr = sortBy.split(":");
+            const sortIndex = sortByStr[0];
+            const sortDirection = sortByStr[1];
+            doSort(sortIndex, sortDirection)
+        }
     }, [contents]);
 
     const sanitisedDataTestId = sanitiseString(dataTestId);
 
-    const handleSort = (rowIndex) => {
-        const isSameColumn = sorted?.rowIndex === rowIndex;
-        const isAscending = sorted?.order === "ascending";
-        const shouldSortDescending = isSameColumn && isAscending;
+    const handleSortClick = (rowIndex, sortDirection) => {
+        const allParams = new URLSearchParams(Array.from(params.entries()));
+        allParams.set("sort", `${rowIndex}:${sortDirection}`);
+        router.replace(`${pathname}?${allParams.toString()}`);
+    }
+
+    const doSort = (rowIndex, sortDirection) => {
+        const isDescending = sortDirection === "desc";
+        const sortColumnIndex = Number(rowIndex);
+        const sourceRows = contents?.body?.rows || [];
         
-        const sortedRows = [...rows].sort((a, b) => {
-            const sortValueA = a.columns[rowIndex]?.sortValue || "";
-            const sortValueB = b.columns[rowIndex]?.sortValue || "";
+        const sortedRows = [...sourceRows].sort((a, b) => {
+            const sortValueA = a.columns[sortColumnIndex]?.sortValue || "";
+            const sortValueB = b.columns[sortColumnIndex]?.sortValue || "";
             
-            if (shouldSortDescending) {
+            if (isDescending) {
                 return sortValueB.localeCompare(sortValueA);
-            } else {
-                return sortValueA.localeCompare(sortValueB);
             }
+            return sortValueA.localeCompare(sortValueB);
         });
         
         setRows(sortedRows);
-        setSorted({ 
-            rowIndex, 
-            order: shouldSortDescending ? "descending" : "ascending" 
-        });
-    };
+        setSorted({ rowIndex: sortColumnIndex, order: isDescending ? "desc" : "asc" });
+    }
 
     const renderTableHeader = () => {
         return (
@@ -49,7 +62,13 @@ export default function Table({ contents, caption, classes, dataTestId, noResult
                                 key={header.label + index} data-testid={`${sanitisedDataTestId}-header-${sanitisedHeaderLabel}`}
                             >
                                 {header.isSortable ?
-                                    <button aria-label="Sort by Legal basis" type="button" data-testid={`${sanitisedDataTestId}-sort-button-${sanitisedHeaderLabel}`} className="ons-table__sort-button" onClick={() => {handleSort(index);}}>
+                                    <button aria-label="Sort by Legal basis" type="button" 
+                                        data-testid={`${sanitisedDataTestId}-sort-button-${sanitisedHeaderLabel}`} 
+                                        className="ons-table__sort-button" 
+                                        onClick={() => {
+                                            handleSortClick(index, index === sorted?.rowIndex ? sorted?.order === "asc" ? "desc" : "asc" : "asc")
+                                        }}
+                                    >
                                         {header.label}
                                         <svg id="sort-sprite-legal-basis-0" className="ons-icon" viewBox="0 0 12 19" xmlns="http://www.w3.org/2000/svg" focusable="false" fill="currentColor" role="img" aria-hidden="true">
                                             <path className="ons-topTriangle" d="M6 0l6 7.2H0L6 0zm0 18.6l6-7.2H0l6 7.2zm0 3.6l6 7.2H0l6-7.2z"></path>

--- a/src/components/table/Table.test.js
+++ b/src/components/table/Table.test.js
@@ -1,9 +1,19 @@
 import React from "react";
-import { render, screen, within } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
 
 import Table from "./Table";
+
+const mockReplace = jest.fn();
+
+jest.mock("next/navigation", () => ({
+    useRouter: jest.fn(() => ({
+        replace: mockReplace,
+    })),
+    usePathname: jest.fn(() => "/migration"),
+    useSearchParams: jest.fn(() => new URLSearchParams()),
+}));
 
 const createTableContents = (overrides = {}) => ({
     headers: [
@@ -30,6 +40,10 @@ const createTableContents = (overrides = {}) => ({
 });
 
 describe("Table", () => {
+    beforeEach(() => {
+        mockReplace.mockClear();
+    });
+
     test("renders table with caption, headers, and rows", () => {
         render(<Table caption="Test caption" classes="custom-class" contents={createTableContents()} dataTestId="test-table" />);
 
@@ -47,23 +61,46 @@ describe("Table", () => {
         expect(screen.getByTestId("test-table-no-data")).toHaveTextContent("No data available");
     });
 
-    test("sorts rows ascending and descending when clicking sortable header", async () => {
-        render(<Table caption="Sortable table" contents={createTableContents()} dataTestId="sortable-table" />);
-
-        const sortButton = screen.getByTestId("sortable-table-sort-button-name");
-
+    test("sorts rows ascending and descending via sortBy prop", () => {
         const getRowOrder = () => [
             screen.getByTestId("sortable-table-cell-0-0").textContent,
             screen.getByTestId("sortable-table-cell-1-0").textContent,
         ];
 
+        const { rerender } = render(
+            <Table caption="Sortable table" contents={createTableContents()} dataTestId="sortable-table" />
+        );
+
         expect(getRowOrder()).toEqual(["Row B", "Row A"]);
 
-        await userEvent.click(sortButton);
+        rerender(
+            <Table caption="Sortable table" contents={createTableContents()} dataTestId="sortable-table" sortBy="0:asc" />
+        );
         expect(getRowOrder()).toEqual(["Row A", "Row B"]);
 
+        rerender(
+            <Table caption="Sortable table" contents={createTableContents()} dataTestId="sortable-table" sortBy="0:desc" />
+        );
+        expect(getRowOrder()).toEqual(["Row B", "Row A"]);
+    });
+
+    test("updates sort query when clicking sortable header", async () => {
+        render(<Table caption="Sortable table" contents={createTableContents()} dataTestId="sortable-table" />);
+
+        const sortButton = screen.getByTestId("sortable-table-sort-button-name");
+
         await userEvent.click(sortButton);
-        expect(getRowOrder()).toEqual(["Row B", "Row A"]); 
+        expect(mockReplace).toHaveBeenCalledWith("/migration?sort=0%3Aasc");
+    });
+
+    test("toggles sort direction when clicking the same column with sortBy set", async () => {
+        render(
+            <Table caption="Sortable table" contents={createTableContents()} dataTestId="sortable-table" sortBy="0:asc" />
+        );
+
+        const sortButton = screen.getByTestId("sortable-table-sort-button-name");
+
+        await userEvent.click(sortButton);
+        expect(mockReplace).toHaveBeenCalledWith("/migration?sort=0%3Adesc");
     });
 });
-


### PR DESCRIPTION
### What

Bug fix: persist sort of migration jobs list - sort column and order is persisted across multiple pages of results
Added "filters coming soon" pane back in. Page looks odd (right aligned) without it

### How to review

On migration job's list page (e.g. `/data-admin/migration`) sort a column then change pages. Column sort and sort order should be persisted across pages

### Who can review

Anyone
