### PR TITLE
Enable dataset series ID editing on unpublished datasets

### DIFF
--- a/src/app/actions/datasetSeries.js
+++ b/src/app/actions/datasetSeries.js
@@ -91,9 +91,8 @@ export async function createDatasetSeries(currentstate, formData) {
     return createResponse(datasetSeriesSubmission, validation, url, httpPost);
 }
 
-export async function updateDatasetSeries(currentstate, formData) {
-    const datasetSeriesSubmissionID = formData.get("dataset-series-id");
-    const url = "/datasets/" + datasetSeriesSubmissionID;
+export async function updateDatasetSeries(originalId, currentstate, formData) {
+    const url = "/datasets/" + originalId;
 
     const datasetSeriesSubmission = getFormData(formData);
     const validation = editSchema.safeParse(datasetSeriesSubmission);

--- a/src/app/series/[id]/edit/page.js
+++ b/src/app/series/[id]/edit/page.js
@@ -66,7 +66,7 @@ export default async function createPage({params}) {
                         currentContacts={dataset.contacts}
                         listOfAllTopics={topics}
                         isPublished={datasetResp?.current?.state === "published"}
-                        action={updateDatasetSeries}
+                        action={updateDatasetSeries.bind(null, id)}
                     />
                 </>
                 : renderErrorPanel()

--- a/src/app/series/[id]/page.js
+++ b/src/app/series/[id]/page.js
@@ -64,7 +64,8 @@ export default async function Dataset({ params, searchParams }) {
     const dataset = datasetResp?.next || datasetResp?.current || datasetResp;
 
     const topicTitles = await convertTopicIDsToTopicTitles(dataset.topics, reqCfg);
-    const seriesSummaryItems = mapSeriesSummary(dataset, editURL, topicTitles);
+    const isPublished = datasetResp?.current?.state === "published";
+    const seriesSummaryItems = mapSeriesSummary(dataset, editURL, topicTitles, isPublished);
     const currentURLPath = (await headers()).get("x-request-pathname") || "";
     const breadcrumbs = generateBreadcrumb(currentURLPath, dataset.title, null);
     const userRoles = (await headers()).get(HEADER_USER_ROLES);

--- a/src/components/design-system/summary-mapper.js
+++ b/src/components/design-system/summary-mapper.js
@@ -133,7 +133,7 @@ const mapRow = (itemName, value, multiValue, action, rows) => {
  * @param {Array} [topicTitles] - Resolved topic titles for the series topics
  * @returns {Array} Summary model for series metadata
  */
-const mapSeriesSummary = (data, editBaseURL, topicTitles) => {
+const mapSeriesSummary = (data, editBaseURL, topicTitles, isPublished) => {
     const contentBody = getBaseSummaryModel("series-metadata");
     const rows = contentBody[0].groups[0].rows;
     const action = {
@@ -147,7 +147,7 @@ const mapSeriesSummary = (data, editBaseURL, topicTitles) => {
         contacts.push(contact.name);
     });
 
-    mapRow("Series ID", data.id, null, null, rows);
+    mapRow("Series ID", data.id, null, isPublished ? null : action, rows);
     mapRow("Type", data.type, null, null, rows);
     mapRow("Title", data.title, null, action, rows);
     mapRow("Description", data.description, null, action, rows);

--- a/src/components/design-system/summary-mapper.test.js
+++ b/src/components/design-system/summary-mapper.test.js
@@ -5,11 +5,11 @@ import { migrationTasksList } from "../../../tests/mocks/migration-tasks.mjs";
 
 describe("mapSeriesSummary", () => {
     test("returns expected object of mapped content items", () => {
-        const mapped = mapSeriesSummary(datasetList.items[2], "test/foo/edit", ["Topic Foo", "Topic Bar"]);
+        const mapped = mapSeriesSummary(datasetList.items[2], "test/foo/edit", ["Topic Foo", "Topic Bar"], true);
         const mappedItems = mapped[0].groups[0].rows;
 
         expect(mappedItems).toHaveLength(12);
-        // expect "Series ID" to have single value and not have "edit" action
+        // expect "Series ID" to have single value and not have "edit" action when published
         expect(mappedItems[0].rowTitle).toBe("Series ID");
         expect(mappedItems[0].rowItems[0].valueList[0]).toMatchObject({text: "mock-quarterly"});
         expect(mappedItems[0].rowItems[0].actions).toBeFalsy();
@@ -90,6 +90,20 @@ describe("mapSeriesSummary", () => {
             id: "action-link-contacts",
             visuallyHiddenText: "Edit Contacts",
             url: "test/foo/edit#dataset-series-contacts"
+        });
+    });
+
+    test("Series ID has an edit action when the series is not published", () => {
+        const mapped = mapSeriesSummary(datasetList.items[2], "test/foo/edit", ["Topic Foo", "Topic Bar"], false);
+        const mappedItems = mapped[0].groups[0].rows;
+
+        // expect "Series ID" to have single value and have "edit" action when not published
+        expect(mappedItems[0].rowTitle).toBe("Series ID");
+        expect(mappedItems[0].rowItems[0].valueList[0]).toMatchObject({text: "mock-quarterly"});
+        expect(mappedItems[0].rowItems[0].actions[0]).toMatchObject({
+            id: "action-link-series-id",
+            visuallyHiddenText: "Edit Series ID",
+            url: "test/foo/edit#dataset-series-series-id"
         });
     });
 

--- a/src/components/form/series/SeriesForm.js
+++ b/src/components/form/series/SeriesForm.js
@@ -65,8 +65,8 @@ export default function SeriesForm({ currentTitle = "", currentID = "", currentD
             <form className="ons-u-mt-m" action={formAction}>
                 <input id="dataset-series-type" name="dataset-series-type" type="hidden" value="static" />
                 <input id="dataset-series-license" name="dataset-series-license" type="hidden" value="Open Government License v3.0" />
-                {currentID != "" ? <input id="dataset-series-id" data-testid="dataset-series-id" name="dataset-series-id" type="hidden" value={id} /> : null}
-                {currentID == "" ?
+                {isPublished && <input id="dataset-series-id" data-testid="dataset-series-id" name="dataset-series-id" type="hidden" value={id} />}
+                {!isPublished &&
                     <TextInput
                         id="dataset-series-id"
                         dataTestId="dataset-series-id"
@@ -79,7 +79,7 @@ export default function SeriesForm({ currentTitle = "", currentID = "", currentD
                         error={(formState.errors && formState.errors.id) ? { id: "dataset-series-id-error", text: formState.errors.id } : null}
                         value={id}
                         onChange={e => setID(e.target.value)}
-                    /> : null
+                    />
                 }
                 <TextInput
                     id="dataset-series-title"


### PR DESCRIPTION
### What

Enable dataset series ID editing on unpublished datasets

### How to review

Pull code and test editing the ID of an unpublished Series. Shouldn't be able to (shouldn't see the option to) edit published series ID's

### Who can review

Anyone
