### PR TITLE
Add migration job preview link

### DIFF
--- a/src/app/migration/[id]/page.js
+++ b/src/app/migration/[id]/page.js
@@ -123,7 +123,7 @@ export default async function MigrationOverview({ params }) {
             />
             <div className="ons-grid ons-u-mt-l ons-u-mb-l">
                 <div className="ons-grid__col ons-col-8@m">
-                    {isStateInReview && canonicalTopic && renderPreviewPanel()}
+                    {displayMigrationJobDetails && canonicalTopic && renderPreviewPanel()}
                     {renderTaskList()}
                     {isStateInReview && renderButtons()}
                 </div>

--- a/src/app/migration/[id]/page.js
+++ b/src/app/migration/[id]/page.js
@@ -29,6 +29,40 @@ export default async function MigrationOverview({ params }) {
 
     const displayMigrationJobDetails = migrationResp.state !== "submitted" && migrationResp.state !== "migrating";
     const associatedDataset = migrationResp.config.target_id
+    const isStateInReview = migrationResp.state === "in_review";
+
+    const renderPreviewPanel = () => {
+        return (
+            <Panel title="Migration job preview" variant="info" dataTestId="migration-job-preview-panel">
+                <p><b>Preview</b><br/>
+                <a href={`/series/${associatedDataset}`} target="_blank">View this series</a> as it will appear on the ONS website</p>
+            </Panel>
+        );
+    }
+
+    const renderButtons = () => {
+        return (
+            <>
+                <StateChangeButton
+                    classes="ons-u-ml-xs ons-u-mt-m ons-u-pt-m"
+                    dataTestId="migration-approve-button"
+                    id="migration-approve-button"
+                    text="Approve"
+                    jobID={id}
+                    jobState={"approved"}
+                    series={associatedDataset}
+                    onClick={updateMigrationJobState}
+                />
+                <LinkButton
+                    dataTestId="migration-reject-button"
+                    text="Reject"
+                    link={`/migration/${id}/reject/${associatedDataset}`}
+                    variants={["secondary"]}
+                    classes="ons-u-ml-xs ons-u-mt-m ons-u-pt-m"
+                />
+            </>
+        );
+    }
 
     const renderSeriesTask = (taskList) => {
         if (!Array.isArray(taskList) || taskList.length > 0) {
@@ -65,26 +99,6 @@ export default async function MigrationOverview({ params }) {
             <>
                 {renderSeriesTask(migrationTasksResp.items)}
                 <Table contents={migrationTaskTableItems} dataTestId={"migration-overview-task-table"} />
-                {
-                    migrationResp.state === "in_review" &&
-                    <><StateChangeButton
-                        classes="ons-u-ml-xs ons-u-mt-m ons-u-pt-m"
-                        dataTestId="migration-approve-button"
-                        id="migration-approve-button"
-                        text="Approve"
-                        jobID={id}
-                        jobState={"approved"}
-                        series={associatedDataset}
-                        onClick={updateMigrationJobState}
-                    />
-                    <LinkButton
-                        dataTestId="migration-reject-button"
-                        text="Reject"
-                        link={`/migration/${id}/reject/${associatedDataset}`}
-                        variants={["secondary"]}
-                        classes="ons-u-ml-xs ons-u-mt-m ons-u-pt-m"
-                    /></>
-                }
             </>
         );
     };
@@ -103,7 +117,9 @@ export default async function MigrationOverview({ params }) {
             />
             <div className="ons-grid ons-u-mt-l ons-u-mb-l">
                 <div className="ons-grid__col ons-col-8@m">
+                    {isStateInReview && renderPreviewPanel()}
                     {renderTaskList()}
+                    {isStateInReview && renderButtons()}
                 </div>
             </div>
         </>

--- a/src/app/migration/[id]/page.js
+++ b/src/app/migration/[id]/page.js
@@ -28,7 +28,7 @@ export default async function MigrationOverview({ params }) {
     }
 
     const displayMigrationJobDetails = migrationResp.state !== "submitted" && migrationResp.state !== "migrating";
-    const associatedDataset = migrationResp.config.target_id
+    const associatedDataset = migrationResp.config?.target_id;
     const isStateInReview = migrationResp.state === "in_review";
 
     const renderPreviewPanel = () => {
@@ -38,7 +38,7 @@ export default async function MigrationOverview({ params }) {
                 <a href={`/series/${associatedDataset}`} target="_blank">View this series</a> as it will appear on the ONS website</p>
             </Panel>
         );
-    }
+    };
 
     const renderButtons = () => {
         return (
@@ -62,7 +62,7 @@ export default async function MigrationOverview({ params }) {
                 />
             </>
         );
-    }
+    };
 
     const renderSeriesTask = (taskList) => {
         if (!Array.isArray(taskList) || taskList.length > 0) {

--- a/src/app/migration/[id]/page.js
+++ b/src/app/migration/[id]/page.js
@@ -33,7 +33,7 @@ export default async function MigrationOverview({ params }) {
 
     const renderPreviewPanel = () => {
         return (
-            <Panel title="Migration job preview" variant="info" dataTestId="migration-job-preview-panel">
+            <Panel dataTestId="migration-job-preview-panel" classes="ons-u-mb-l">
                 <p><b>Preview</b><br/>
                 <a href={`/series/${associatedDataset}`} target="_blank">View this series</a> as it will appear on the ONS website</p>
             </Panel>

--- a/src/app/migration/[id]/page.js
+++ b/src/app/migration/[id]/page.js
@@ -16,9 +16,9 @@ import { updateMigrationJobState } from "@/app/actions/migrationJob";
 
 export default async function MigrationOverview({ params }) {
     const { id } = await params;
-    const reqCfg = await SSRequestConfig(cookies, "migration-service");
+    const msReqCfg = await SSRequestConfig(cookies, "migration-service");
 
-    const migrationResp = await httpGet(reqCfg, `/migration-jobs/${id}`);
+    const migrationResp = await httpGet(msReqCfg, `/migration-jobs/${id}`);
     if (migrationResp.ok != null && !migrationResp.ok) {
         return (
             <Panel title="Error" variant="error" dataTestId="migrations-job-overview-response-error">
@@ -27,15 +27,21 @@ export default async function MigrationOverview({ params }) {
         );
     }
 
-    const displayMigrationJobDetails = migrationResp.state !== "submitted" && migrationResp.state !== "migrating";
     const associatedDataset = migrationResp.config?.target_id;
+
+    const dsReqCfg = await SSRequestConfig(cookies, "api-router");
+    const datasetResp = await httpGet(dsReqCfg, `/datasets/${associatedDataset}`);
+    const dataset = datasetResp?.next || datasetResp?.current || datasetResp;
+    const canonicalTopic = dataset?.topics?.[0] || null;
+
+    const displayMigrationJobDetails = migrationResp.state !== "submitted" && migrationResp.state !== "migrating";
     const isStateInReview = migrationResp.state === "in_review";
 
     const renderPreviewPanel = () => {
         return (
             <Panel dataTestId="migration-job-preview-panel" classes="ons-u-mb-l">
                 <p><b>Preview</b><br/>
-                <a href={`/series/${associatedDataset}`} target="_blank">View this series</a> as it will appear on the ONS website</p>
+                <a href={`/${canonicalTopic}/datasets/${associatedDataset}`} target="_blank">View this series</a> as it will appear on the ONS website</p>
             </Panel>
         );
     };
@@ -84,7 +90,7 @@ export default async function MigrationOverview({ params }) {
             return (<p>Dataset series migration is still in progress. Try refreshing the page.</p>);
         }
 
-        const migrationTasksResp = await httpGet(reqCfg, `/migration-jobs/${id}/tasks`);
+        const migrationTasksResp = await httpGet(msReqCfg, `/migration-jobs/${id}/tasks`);
         if (migrationTasksResp.ok != null && !migrationTasksResp.ok) {
             return (
                 <Panel title="Error" variant="error" dataTestId="migrations-job-overview-response-error">
@@ -117,7 +123,7 @@ export default async function MigrationOverview({ params }) {
             />
             <div className="ons-grid ons-u-mt-l ons-u-mb-l">
                 <div className="ons-grid__col ons-col-8@m">
-                    {isStateInReview && renderPreviewPanel()}
+                    {isStateInReview && canonicalTopic && renderPreviewPanel()}
                     {renderTaskList()}
                     {isStateInReview && renderButtons()}
                 </div>

--- a/src/app/migration/[id]/page.js
+++ b/src/app/migration/[id]/page.js
@@ -61,12 +61,13 @@ export default async function MigrationOverview({ params }) {
 
         const migrationTaskTableItems = mapMigrationJobTable(migrationTasksResp.items);
 
-        if (migrationResp.state == "in_review") {
-            return (
-                <>
-                    {renderSeriesTask(migrationTasksResp.items)}
-                    <Table contents={migrationTaskTableItems} dataTestId={"migration-overview-task-table"} />
-                    <StateChangeButton
+        return (
+            <>
+                {renderSeriesTask(migrationTasksResp.items)}
+                <Table contents={migrationTaskTableItems} dataTestId={"migration-overview-task-table"} />
+                {
+                    migrationResp.state === "in_review" &&
+                    <><StateChangeButton
                         classes="ons-u-ml-xs ons-u-mt-m ons-u-pt-m"
                         dataTestId="migration-approve-button"
                         id="migration-approve-button"
@@ -82,15 +83,8 @@ export default async function MigrationOverview({ params }) {
                         link={`/migration/${id}/reject/${associatedDataset}`}
                         variants={["secondary"]}
                         classes="ons-u-ml-xs ons-u-mt-m ons-u-pt-m"
-                    />
-                </>
-            );
-        }
-
-        return (
-            <>
-                {renderSeriesTask(migrationTasksResp.items)}
-                <Table contents={migrationTaskTableItems} dataTestId={"migration-overview-task-table"} />
+                    /></>
+                }
             </>
         );
     };

--- a/tests/component/migrationOverview.spec.js
+++ b/tests/component/migrationOverview.spec.js
@@ -103,6 +103,20 @@ test.describe("Migration overview page", () => {
         await expect(page.getByTestId("success-panel")).toContainText("Migration for new-dataset reverted.");
     });
 
+    test.describe("Preview panel", () => {
+        test("Shows when expected", async ({ page, context }) => {
+            setValidAuthCookies(context);
+            await page.goto("./migration/4");
+            await expect(page.getByTestId("migration-job-preview-panel")).toBeVisible();
+        });
+
+        test("Doesn't show when expected", async ({ page, context }) => {
+            setValidAuthCookies(context);
+            await page.goto("./migration/1");
+            await expect(page.getByTestId("migration-job-preview-panel")).not.toBeVisible();
+        });
+    });
+
     test.describe("Handles API error", () => {
         test("When 404 is returned", async ({ page, context }) => {
             setValidAuthCookies(context);

--- a/tests/mocks/migration-jobs.mjs
+++ b/tests/mocks/migration-jobs.mjs
@@ -119,7 +119,7 @@ export const migrationJobsList = {
             "source_id": "/economy/inflationandpriceindices/datasets/consumerpriceinflation/data",
             "state": "reverted",
             "config": {
-                "target_id": "new-dataset",
+                "target_id": "cpih",
             },
             "type": "static_dataset",
             "label": "Population estimates"


### PR DESCRIPTION
### What

Add a link for users to preview migrated datasets on the website

### How to review

Navigate to a migration job detail page i.e. `data-admin/migration/{migration-job-number}` of a migration job is in at least `in_progress` (or further) status and see that a preview panel is visible and links to dataset overview page

### Who can review

Anyone