### PR TITLE
Pin turbopack.root and outputFileTracingRoot to prevent picking the wrong lockfile

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,13 @@
 /** @type {import("next").NextConfig} */
 
+const path = require("path");
+
 module.exports = {
+  // Pin project root so Turbopack does not walk up to a parent lockfile.
+  turbopack: {
+    root: path.join(__dirname),
+  },
+  outputFileTracingRoot: path.join(__dirname),
   output: "standalone",
   basePath: "/data-admin",
   experimental: {


### PR DESCRIPTION
### What

Pin `turbopack.root` and `outputFileTracingRoot` to prevent picking the wrong project root from a parent lockfile

### How to review

Sanity check

### Who can review

Anyone