### PR TITLE
map all expected file extensions to media types on upload

### DIFF
--- a/src/components/file-upload/bind.js
+++ b/src/components/file-upload/bind.js
@@ -3,6 +3,16 @@ import { logError } from "@/utils/log/log";
 
 const FIVE_MEGABYTES = 5 * 1024 * 1024;
 
+// Mapping of file extensions to MIME types which are defined in the dataset API.
+const EXTENSION_TO_MIME_TYPE = {
+    csv: "text/csv",
+    sdmx: "application/vnd.sdmx.structurespecificdata+xml",
+    xls: "application/vnd.ms-excel",
+    xlsx: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    csdb: "text/plain",
+    csvw: "application/ld+json"
+};
+
 const RESUMABLE_OPTIONS = {
     isPublishable: true,
     licence: "Open Government Licence v3.0",
@@ -53,7 +63,17 @@ const bindFileUploadInput = (elementID, uploadBaseURL, uploadFilePath, accessTok
 };
 
 const onFileAdded = (resumable, resumableOptions, file, handleFileStart) => {
-    resumable.opts.query = resumableOptions;
+    // ResumableJS uses the browser's File.type to set `resumableType` and will default to an empty string if the type is not recognised.
+    // As many file types supported by the dataset API are not recognised by the browser,
+    // EXTENSION_TO_MIME_TYPE is used to map the file extension to the correct MIME type.
+    const extension = formatFromFilename(file.fileName || "").toLowerCase();
+    const mimeType = EXTENSION_TO_MIME_TYPE[extension];
+
+    resumable.opts.query = {
+        ...resumableOptions,
+        resumableType: mimeType,
+    };
+
     resumable.upload();
     handleFileStart();
 };

--- a/src/components/file-upload/bind.test.js
+++ b/src/components/file-upload/bind.test.js
@@ -11,15 +11,35 @@ const mockResumableOptions = {
     path: "test-path",
 }
 
-test("onFileAdded begins upload and sets correct state", () => {
-    const onStart = jest.fn();
-    expect(uploadFunc.mock.calls).toHaveLength(0);
-    expect(onStart.mock.calls).toHaveLength(0);
+describe("onFileAdded", () => {
+    it("begins upload and sets the correct state", () => {
+        const onStart = jest.fn();
+        expect(uploadFunc.mock.calls).toHaveLength(0);
+        expect(onStart.mock.calls).toHaveLength(0);
 
-    onFileAdded(mockResumable, mockResumableOptions, {}, onStart);
-    expect(uploadFunc.mock.calls).toHaveLength(1);
-    expect(onStart.mock.calls).toHaveLength(1);
-});
+        onFileAdded(mockResumable, mockResumableOptions, {}, onStart);
+        expect(uploadFunc.mock.calls).toHaveLength(1);
+        expect(onStart.mock.calls).toHaveLength(1);
+    })
+
+    it("sets the correct MIME type for all supported file types", () => {
+        const onStart = jest.fn();
+        const testFiles = [
+            { fileName: "test.csv", expectedMimeType: "text/csv" },
+            { fileName: "test.sdmx", expectedMimeType: "application/vnd.sdmx.structurespecificdata+xml" },
+            { fileName: "test.xls", expectedMimeType: "application/vnd.ms-excel" },
+            { fileName: "test.xlsx", expectedMimeType: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" },
+            { fileName: "test.csdb", expectedMimeType: "text/plain" },
+            { fileName: "test.csvw", expectedMimeType: "application/ld+json" }
+        ];
+
+        testFiles.forEach(testFile => {
+            mockResumable.opts.query = {};
+            onFileAdded(mockResumable, mockResumableOptions, testFile, onStart);
+            expect(mockResumable.opts.query.resumableType).toBe(testFile.expectedMimeType);
+        });
+    })
+})
 
 test("onFileProgress sets the correct state ", () => {
     const progressFunc = jest.fn(() => 0.5);


### PR DESCRIPTION
### What

Ticket: https://officefornationalstatistics.atlassian.net/browse/DIS-5216

- Fixed bug where certain file extensions were failing to upload.
- This was caused by `ResumableJS` using the browser's `File.type` to set the `resumableType` field when making calls to the upload service. As some of the file extensions used by the Dataset API are not recognised by the browser, `resumableType` gets set to `""` by default and causes a `400` error in the upload service.
- Bug was fixed by creating a `EXTENSION_TO_MIME_TYPE` map to ensure all file extensions accepted by the Dataset API, will have their associated media type set.

Note:
- File extension to media type is not necessarily a one to one relationship and some of these file extensions are not seen as valid extensions but this is what the Dataset API accepts and what has been agreed on.

### How to review

- Go to the "create edition" or "create version" page and upload files of all the accepted file extensions. None of these uploads should cause an error.
- Before submitting the edition/version form, remove the `.csvw` file as this will not work due to another bug. ([Ticket here](https://officefornationalstatistics.atlassian.net/browse/DIS-5217))
- After creating the edition/version, check that all the files can be downloaded

### Who can review

- Anyone
