### PR TITLE
Fix/correct licence spelling on series submission

### DIFF
--- a/src/components/design-system/summary-mapper.test.js
+++ b/src/components/design-system/summary-mapper.test.js
@@ -49,7 +49,7 @@ describe("mapSeriesSummary", () => {
         expect(mappedItems[5].rowItems[0].actions).toBeFalsy();
         // expect "Licence" to have single value and have "edit" action
         expect(mappedItems[6].rowTitle).toBe("Licence");
-        expect(mappedItems[6].rowItems[0].valueList[0]).toMatchObject({text: "My License"});
+        expect(mappedItems[6].rowItems[0].valueList[0]).toMatchObject({text: "My Licence"});
         expect(mappedItems[6].rowItems[0].actions).toBeFalsy();
         // expect "Next release" to have single value and have "edit" action
         expect(mappedItems[7].rowTitle).toBe("Next release");

--- a/src/components/form/series/SeriesForm.js
+++ b/src/components/form/series/SeriesForm.js
@@ -64,7 +64,7 @@ export default function SeriesForm({ currentTitle = "", currentID = "", currentD
             {renderFailure()}
             <form className="ons-u-mt-m" action={formAction}>
                 <input id="dataset-series-type" name="dataset-series-type" type="hidden" value="static" />
-                <input id="dataset-series-license" name="dataset-series-license" type="hidden" value="Open Government License v3.0" />
+                <input id="dataset-series-license" name="dataset-series-license" type="hidden" value="Open Government Licence v3.0" />
                 {isPublished && <input id="dataset-series-id" data-testid="dataset-series-id" name="dataset-series-id" type="hidden" value={id} />}
                 {!isPublished &&
                     <TextInput

--- a/tests/component/seriesOverview.spec.js
+++ b/tests/component/seriesOverview.spec.js
@@ -27,7 +27,7 @@ test.describe("Series overview page", () => {
         await expect(page.locator("#topics")).toContainText("Business");
         await expect(page.getByTestId("action-link-topics")).toBeVisible();
         await expect(page.locator("#last-updated")).toContainText("1 January 2000");
-        await expect(page.locator("#licence")).toContainText("My License");
+        await expect(page.locator("#licence")).toContainText("My Licence");
         await expect(page.locator("#next-release")).toContainText("TBC");
         await expect(page.locator("#keywords")).toContainText("mock");
         await expect(page.locator("#keywords")).toContainText("test");

--- a/tests/mocks/datasets.mjs
+++ b/tests/mocks/datasets.mjs
@@ -27,7 +27,7 @@ export const datasetList = {
                 "unit_of_measure": "Percentage",
                 "topics": ["1001", "2002"],
                 "last_updated": "2000-01-01T07:00:00.000Z",
-                "license": "My License",
+                "license": "My Licence",
                 "publisher": {
                     "href": "https://www.ons.gov.uk",
                     "name": "ONS"
@@ -56,7 +56,7 @@ export const datasetList = {
                 "unit_of_measure": "Percentage",
                 "topics": ["1001", "2002"],
                 "last_updated": "2000-01-01T07:00:00.000Z",
-                "license": "My License",
+                "license": "My Licence",
                 "publisher": {
                     "href": "https://www.ons.gov.uk",
                     "name": "ONS"
@@ -104,7 +104,7 @@ export const datasetList = {
                 }
             ],
             "last_updated": "2000-01-01T07:00:00.000Z",
-            "license": "My License",
+            "license": "My Licence",
             "publisher": {
                 "href": "https://www.ons.gov.uk",
                 "name": "ONS"
@@ -137,7 +137,7 @@ export const datasetList = {
                     }
                 ],
                 "last_updated": "2000-01-01T07:00:00.000Z",
-                "license": "My License",
+                "license": "My Licence",
                 "publisher": {
                     "href": "https://www.ons.gov.uk",
                     "name": "ONS"
@@ -160,7 +160,7 @@ export const datasetList = {
                 }
             ],
             "last_updated": "invalid/missing date",
-            "license": "My Minimal License",
+            "license": "My Minimal Licence",
             "type": "static"
         },
         ...automatedDatasetList(),


### PR DESCRIPTION
### What

Ticket: https://officefornationalstatistics.atlassian.net/browse/DIS-5222

- Change spelling of `license` to `licence` when creating a new series
- Updated test data

### How to review

- Create a new series and check that the new dataset record has `"license": "Open Government Licence v3.0"`

### Who can review

- Anyone
